### PR TITLE
feat: uint8list instead of int list

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ services.forEach((service) {
 var characteristics = service.characteristics;
 for(BluetoothCharacteristic c in characteristics) {
     if (c.properties.read) {
-        List<int> value = await c.read();
+        Uint8List value = await c.read();
         print(value);
     }
 }
@@ -326,10 +326,10 @@ import 'dart:math';
 //    2. it can only be used *with* response to avoid data loss
 //    3. The characteristic must be designed to support split data
 extension splitWrite on BluetoothCharacteristic {
-  Future<void> splitWrite(List<int> value, {int timeout = 15}) async {
+  Future<void> splitWrite(Uint8List value, {int timeout = 15}) async {
     int chunk = min(device.mtuNow - 3, 512); // 3 bytes BLE overhead, 512 bytes max
     for (int i = 0; i < value.length; i += chunk) {
-      List<int> subvalue = value.sublist(i, min(i + chunk, value.length));
+      Uint8List subvalue = value.sublist(i, min(i + chunk, value.length));
       await write(subvalue, withoutResponse:false, timeout: timeout);
     }
   }
@@ -384,7 +384,7 @@ await characteristic.setNotifyValue(true);
 // Reads all descriptors
 var descriptors = characteristic.descriptors;
 for(BluetoothDescriptor d in descriptors) {
-    List<int> value = await d.read();
+    Uint8List value = await d.read();
     print(value);
 }
 

--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -2279,7 +2279,7 @@ public class FlutterBluePlusPlugin implements
             LogLevel level = LogLevel.DEBUG;
             log(level, "onCharacteristicChanged:");
             log(level, "  chr: " + uuidStr(characteristic.getUuid()));
-            onCharacteristicReceived(gatt, characteristic, value, status);
+            onCharacteristicReceived(gatt, characteristic, value, BluetoothGatt.GATT_SUCCESS);
         }
 
         @Override
@@ -2317,7 +2317,7 @@ public class FlutterBluePlusPlugin implements
 
             // what data did we write?
             String key = remoteId + ":" + serviceUuid + ":" + characteristicUuid;
-            []byte value = mWriteChr.get(key) != null ? mWriteChr.get(key) : new byte[0];
+            byte[] value = mWriteChr.get(key) != null ? mWriteChr.get(key) : new byte[0];
             mWriteChr.remove(key);
 
             // see: BmCharacteristicData

--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -106,8 +106,8 @@ public class FlutterBluePlusPlugin implements
     private final Map<String, BluetoothDevice> mBondingDevices = new ConcurrentHashMap<>();
     private final Map<String, Integer> mMtu = new ConcurrentHashMap<>();
     private final Map<String, BluetoothGatt> mAutoConnected = new ConcurrentHashMap<>();
-    private final Map<String, String> mWriteChr = new ConcurrentHashMap<>();
-    private final Map<String, String> mWriteDesc = new ConcurrentHashMap<>();
+    private final Map<String, byte[]> mWriteChr = new ConcurrentHashMap<>();
+    private final Map<String, byte[]> mWriteDesc = new ConcurrentHashMap<>();
     private final Map<String, String> mAdvSeen = new ConcurrentHashMap<>();
     private final Map<String, Integer> mScanCounts = new ConcurrentHashMap<>();
     private HashMap<String, Object> mScanFilters = new HashMap<String, Object>();
@@ -370,7 +370,7 @@ public class FlutterBluePlusPlugin implements
                     break;
                 }
 
-               case "getAdapterName":
+                case "getAdapterName":
                 {
                     ArrayList<String> permissions = new ArrayList<>();
 
@@ -578,8 +578,8 @@ public class FlutterBluePlusPlugin implements
                         for (int i = 0; i < withMsd.size(); i++) {
                             HashMap<String, Object> m = (HashMap<String, Object>) withMsd.get(i);
                             int id =                    (int) m.get("manufacturer_id");
-                            byte[] mdata = hexToBytes((String) m.get("data"));
-                            byte[] mask =  hexToBytes((String) m.get("mask"));
+                            byte[] mdata =              (byte[]) m.get("data");
+                            byte[] mask =               (byte[]) m.get("mask");
                             ScanFilter f = null;
                             if (mask.length == 0) {
                                 f = new ScanFilter.Builder().setManufacturerData(id, mdata).build();
@@ -592,9 +592,9 @@ public class FlutterBluePlusPlugin implements
                         // service data
                         for (int i = 0; i < withServiceData.size(); i++) {
                             HashMap<String, Object> m = (HashMap<String, Object>) withServiceData.get(i);
-                            ParcelUuid s = ParcelUuid.fromString((String) m.get("service"));
-                            byte[] mdata =             hexToBytes((String) m.get("data"));
-                            byte[] mask =              hexToBytes((String) m.get("mask"));
+                            ParcelUuid s =              ParcelUuid.fromString((String) m.get("service"));
+                            byte[] mdata =              (byte[]) m.get("data");
+                            byte[] mask =               (byte[]) m.get("mask");
                             ScanFilter f = null;
                             if (mask.length == 0) {
                                 f = new ScanFilter.Builder().setServiceData(s, mdata).build();
@@ -883,7 +883,7 @@ public class FlutterBluePlusPlugin implements
                     String serviceUuid =          (String) data.get("service_uuid");
                     String secondaryServiceUuid = (String) data.get("secondary_service_uuid");
                     String characteristicUuid =   (String) data.get("characteristic_uuid");
-                    String value =                (String) data.get("value");
+                    byte[] value =                (byte[]) data.get("value");
                     int writeTypeInt =               (int) data.get("write_type");
                     boolean allowLongWrite =        ((int) data.get("allow_long_write")) != 0;
 
@@ -927,7 +927,7 @@ public class FlutterBluePlusPlugin implements
 
                     // check maximum payload
                     int maxLen = getMaxPayload(remoteId, writeType, allowLongWrite);
-                    int dataLen = hexToBytes(value).length;
+                    int dataLen = value.length;
                     if (dataLen > maxLen) {
                         String a = writeTypeInt == 0 ? "withResponse" : "withoutResponse";
                         String b = writeTypeInt == 0 ? (allowLongWrite ? ", allowLongWrite" : ", noLongWrite") : "";
@@ -943,7 +943,7 @@ public class FlutterBluePlusPlugin implements
                     // write characteristic
                     if (Build.VERSION.SDK_INT >= 33) { // Android 13 (August 2022)
 
-                        int rv = gatt.writeCharacteristic(characteristic, hexToBytes(value), writeType);
+                        int rv = gatt.writeCharacteristic(characteristic, value, writeType);
 
                         if (rv != BluetoothStatusCodes.SUCCESS) {
                             String s = "gatt.writeCharacteristic() returned " + rv + " : " + bluetoothStatusString(rv);
@@ -953,7 +953,7 @@ public class FlutterBluePlusPlugin implements
 
                     } else {
                         // set value
-                        if(!characteristic.setValue(hexToBytes(value))) {
+                        if(!characteristic.setValue(value)) {
                             result.error("writeCharacteristic", "characteristic.setValue() returned false", null);
                             break;
                         }
@@ -1028,7 +1028,7 @@ public class FlutterBluePlusPlugin implements
                     String secondaryServiceUuid = (String) data.get("secondary_service_uuid");
                     String characteristicUuid =   (String) data.get("characteristic_uuid");
                     String descriptorUuid =       (String) data.get("descriptor_uuid");
-                    String value =                (String) data.get("value");
+                    byte[] value =                (byte[]) data.get("value");
 
                     // check connection
                     BluetoothGatt gatt = mConnectedDevices.get(remoteId);
@@ -1059,9 +1059,9 @@ public class FlutterBluePlusPlugin implements
 
                     // check mtu
                     int mtu = mMtu.get(remoteId);
-                    if ((mtu-3) < hexToBytes(value).length) {
+                    if ((mtu-3) < value.length) {
                         String s = "data longer than mtu allows. dataLength: " +
-                            hexToBytes(value).length + "> max: " + (mtu-3);
+                            value.length + "> max: " + (mtu-3);
                         result.error("writeDescriptor", s, null);
                         break;
                     }
@@ -1073,7 +1073,7 @@ public class FlutterBluePlusPlugin implements
                     // write descriptor
                     if (Build.VERSION.SDK_INT >= 33) { // Android 13 (August 2022)
 
-                        int rv = gatt.writeDescriptor(descriptor, hexToBytes(value));
+                        int rv = gatt.writeDescriptor(descriptor, value);
                         if (rv != BluetoothStatusCodes.SUCCESS) {
                             String s = "gatt.writeDescriptor() returned " + rv + " : " + bluetoothStatusString(rv);
                             result.error("writeDescriptor", s, null);
@@ -1083,7 +1083,7 @@ public class FlutterBluePlusPlugin implements
                     } else {
 
                         // Set descriptor
-                        if(!descriptor.setValue(hexToBytes(value))){
+                        if(!descriptor.setValue(value)){
                             result.error("writeDescriptor", "descriptor.setValue() returned false", null);
                             break;
                         }
@@ -1180,7 +1180,7 @@ public class FlutterBluePlusPlugin implements
 
                     // remember the data we are writing
                     String key = remoteId + ":" + serviceUuid + ":" + characteristicUuid + ":" + CCCD;
-                    mWriteDesc.put(key, bytesToHex(descriptorValue));
+                    mWriteDesc.put(key, descriptorValue);
 
                     // write descriptor
                     if (Build.VERSION.SDK_INT >= 33) { // Android 13 (August 2022)
@@ -2263,7 +2263,7 @@ public class FlutterBluePlusPlugin implements
                 response.put("secondary_service_uuid", uuidStr(pair.secondary));
             }
             response.put("characteristic_uuid", uuidStr(characteristic.getUuid()));
-            response.put("value", bytesToHex(value));
+            response.put("value", value);
             response.put("success", status == BluetoothGatt.GATT_SUCCESS ? 1 : 0);
             response.put("error_code", status);
             response.put("error_string", gattErrorString(status));
@@ -2317,7 +2317,7 @@ public class FlutterBluePlusPlugin implements
 
             // what data did we write?
             String key = remoteId + ":" + serviceUuid + ":" + characteristicUuid;
-            String value = mWriteChr.get(key) != null ? mWriteChr.get(key) : "";
+            []byte value = mWriteChr.get(key) != null ? mWriteChr.get(key) : new byte[0];
             mWriteChr.remove(key);
 
             // see: BmCharacteristicData
@@ -2357,7 +2357,7 @@ public class FlutterBluePlusPlugin implements
             }
             response.put("characteristic_uuid", uuidStr(descriptor.getCharacteristic().getUuid()));
             response.put("descriptor_uuid", uuidStr(descriptor.getUuid()));
-            response.put("value", bytesToHex(value));
+            response.put("value", value);
             response.put("success", status == BluetoothGatt.GATT_SUCCESS ? 1 : 0);
             response.put("error_code", status);
             response.put("error_string", gattErrorString(status));
@@ -2385,7 +2385,7 @@ public class FlutterBluePlusPlugin implements
 
             // what data did we write?
             String key = remoteId + ":" + serviceUuid + ":" + characteristicUuid + ":" + descriptorUuid;
-            String value = mWriteDesc.get(key) != null ? mWriteDesc.get(key) : "";
+            byte[] value = mWriteDesc.get(key) != null ? mWriteDesc.get(key) : new byte[0];
             mWriteDesc.remove(key);
 
             // see: BmDescriptorData
@@ -2525,20 +2525,20 @@ public class FlutterBluePlusPlugin implements
         Map<ParcelUuid, byte[]> serviceData  = adv != null ?  adv.getServiceData()               : null;
 
         // Manufacturer Specific Data
-        HashMap<Integer, String> manufDataB = new HashMap<>();
+        HashMap<Integer, byte[]> manufDataB = new HashMap<>();
         if (manufData != null) {
             for (Map.Entry<Integer, byte[]> entry : manufData.entrySet()) {
-                manufDataB.put(entry.getKey(), bytesToHex(entry.getValue()));
+                manufDataB.put(entry.getKey(), entry.getValue());
             }
         }
 
         // Service Data
-        HashMap<String, Object> serviceDataB = new HashMap<>();
+        HashMap<String, byte[]> serviceDataB = new HashMap<>();
         if (serviceData != null) {
             for (Map.Entry<ParcelUuid, byte[]> entry : serviceData.entrySet()) {
                 ParcelUuid key = entry.getKey();
                 byte[] value = entry.getValue();
-                serviceDataB.put(uuidStr(key.getUuid()), bytesToHex(value));
+                serviceDataB.put(uuidStr(key.getUuid()), value);
             }
         }
 
@@ -2767,21 +2767,6 @@ public class FlutterBluePlusPlugin implements
         } catch (Exception e) {
             return false;
         }
-    }
-
-    private static byte[] hexToBytes(String s) {
-        if (s == null) {
-            return new byte[0];
-        }
-        int len = s.length();
-        byte[] data = new byte[len / 2];
-
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                                + Character.digit(s.charAt(i+1), 16));
-        }
-
-        return data;
     }
 
     private static String bytesToHex(byte[] bytes) {

--- a/example/lib/widgets/characteristic_tile.dart
+++ b/example/lib/widgets/characteristic_tile.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import "../utils/snackbar.dart";
-
 import "descriptor_tile.dart";
 
 class CharacteristicTile extends StatefulWidget {
@@ -19,9 +19,9 @@ class CharacteristicTile extends StatefulWidget {
 }
 
 class _CharacteristicTileState extends State<CharacteristicTile> {
-  List<int> _value = [];
+  Uint8List _value = Uint8List(0);
 
-  late StreamSubscription<List<int>> _lastValueSubscription;
+  late StreamSubscription<Uint8List> _lastValueSubscription;
 
   @override
   void initState() {
@@ -42,9 +42,9 @@ class _CharacteristicTileState extends State<CharacteristicTile> {
 
   BluetoothCharacteristic get c => widget.characteristic;
 
-  List<int> _getRandomBytes() {
+  Uint8List _getRandomBytes() {
     final math = Random();
-    return [math.nextInt(255), math.nextInt(255), math.nextInt(255), math.nextInt(255)];
+    return Uint8List.fromList([math.nextInt(255), math.nextInt(255), math.nextInt(255), math.nextInt(255)]);
   }
 
   Future onReadPressed() async {
@@ -131,7 +131,7 @@ class _CharacteristicTileState extends State<CharacteristicTile> {
 
   Widget buildButtonRow(BuildContext context) {
     bool read = widget.characteristic.properties.read;
-    bool write = widget.characteristic.properties.write;
+    bool write = widget.characteristic.properties.write || widget.characteristic.properties.writeWithoutResponse;
     bool notify = widget.characteristic.properties.notify;
     bool indicate = widget.characteristic.properties.indicate;
     return Row(

--- a/example/lib/widgets/descriptor_tile.dart
+++ b/example/lib/widgets/descriptor_tile.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
@@ -16,9 +17,9 @@ class DescriptorTile extends StatefulWidget {
 }
 
 class _DescriptorTileState extends State<DescriptorTile> {
-  List<int> _value = [];
+  Uint8List _value = Uint8List(0);
 
-  late StreamSubscription<List<int>> _lastValueSubscription;
+  late StreamSubscription<Uint8List> _lastValueSubscription;
 
   @override
   void initState() {
@@ -39,9 +40,9 @@ class _DescriptorTileState extends State<DescriptorTile> {
 
   BluetoothDescriptor get d => widget.descriptor;
 
-  List<int> _getRandomBytes() {
+  Uint8List _getRandomBytes() {
     final math = Random();
-    return [math.nextInt(255), math.nextInt(255), math.nextInt(255), math.nextInt(255)];
+    return Uint8List.fromList([math.nextInt(255), math.nextInt(255), math.nextInt(255), math.nextInt(255)]);
   }
 
   Future onReadPressed() async {

--- a/example/lib/widgets/scan_result_tile.dart
+++ b/example/lib/widgets/scan_result_tile.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
@@ -36,15 +37,15 @@ class _ScanResultTileState extends State<ScanResultTile> {
     super.dispose();
   }
 
-  String getNiceHexArray(List<int> bytes) {
+  String getNiceHexArray(Uint8List bytes) {
     return '[${bytes.map((i) => i.toRadixString(16).padLeft(2, '0')).join(', ')}]';
   }
 
-  String getNiceManufacturerData(List<List<int>> data) {
+  String getNiceManufacturerData(List<Uint8List> data) {
     return data.map((val) => '${getNiceHexArray(val)}').join(', ').toUpperCase();
   }
 
-  String getNiceServiceData(Map<Guid, List<int>> data) {
+  String getNiceServiceData(Map<Guid, Uint8List> data) {
     return data.entries.map((v) => '${v.key}: ${getNiceHexArray(v.value)}').join(', ').toUpperCase();
   }
 

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -503,7 +503,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             NSString  *secondaryServiceUuid = args[@"secondary_service_uuid"];
             NSNumber  *writeTypeNumber      = args[@"write_type"];
             NSNumber  *allowLongWrite       = args[@"allow_long_write"];
-            NSString  *value                = args[@"value"];
+            NSData    *value                = args[@"value"];
             
             // Find peripheral
             CBPeripheral *peripheral = [self getConnectedPeripheral:remoteId];
@@ -521,7 +521,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
             // check maximum payload
             int maxLen = [self getMaxPayload:peripheral forType:writeType allowLongWrite:[allowLongWrite boolValue]];
-            int dataLen = (int) [self convertHexToData:value].length;
+            int dataLen = value.length;
             if (dataLen > maxLen) {
                 NSString* t = [writeTypeNumber intValue] == 0 ? @"withResponse" : @"withoutResponse";
                 NSString* a = [allowLongWrite boolValue] ? @", allowLongWrite" : @", noLongWrite";
@@ -572,7 +572,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             [self.writeChrs setObject:value forKey:key];
                   
             // Write to characteristic
-            [peripheral writeValue:[self convertHexToData:value] forCharacteristic:characteristic type:writeType];
+            [peripheral writeValue:value forCharacteristic:characteristic type:writeType];
 
             // remember the most recent write withoutResponse
             if (writeType == CBCharacteristicWriteWithoutResponse) {
@@ -631,7 +631,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             NSString  *serviceUuid          = args[@"service_uuid"];
             NSString  *secondaryServiceUuid = args[@"secondary_service_uuid"];
             NSString  *characteristicUuid   = args[@"characteristic_uuid"];
-            NSString  *value                = args[@"value"];
+            NSData    *value                = args[@"value"];
 
             // Find peripheral
             CBPeripheral *peripheral = [self getConnectedPeripheral:remoteId];
@@ -643,7 +643,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
             // check mtu
             int mtu = (int) [self getMtu:peripheral];
-            int dataLen = (int) [self convertHexToData:value].length;
+            int dataLen = value.length;
             if ((mtu-3) < dataLen) {
                 NSString* f = @"data is longer than MTU allows. dataLen: %d > maxDataLen: %d";
                 NSString* s = [NSString stringWithFormat:f, dataLen, (mtu-3)];
@@ -675,7 +675,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             [self.writeDescs setObject:value forKey:key];
 
             // Write descriptor
-            [peripheral writeValue:[self convertHexToData:value] forDescriptor:descriptor];
+            [peripheral writeValue:value forDescriptor:descriptor];
 
             result(@YES);
         }
@@ -1440,7 +1440,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         @"service_uuid":            [pair.primary.UUID uuidStr],
         @"secondary_service_uuid":  pair.secondary ? [pair.secondary.UUID uuidStr] : [NSNull null],
         @"characteristic_uuid":     [characteristic.UUID uuidStr],
-        @"value":                   [self convertDataToHex:characteristic.value],
+        @"value":                   characteristic.value,
         @"success":                 error == nil ? @(1) : @(0),
         @"error_string":            error ? [error localizedDescription] : @"success",
         @"error_code":              error ? @(error.code) : @(0),
@@ -1473,7 +1473,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
     // what data did we write?
     NSString *key = [NSString stringWithFormat:@"%@:%@:%@", remoteId, serviceUuid, characteristicUuid];
-    NSString *value = self.writeChrs[key] ? self.writeChrs[key] : @"";
+    NSData *value = self.writeChrs[key] ? self.writeChrs[key] : [NSMutableData data];
     [self.writeChrs removeObjectForKey:key];
 
     // See BmCharacteristicData
@@ -1526,7 +1526,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         @"secondary_service_uuid": pair.secondary ? [pair.secondary.UUID uuidStr] : [NSNull null],
         @"characteristic_uuid":    [characteristic.UUID uuidStr],
         @"descriptor_uuid":        CCCD,
-        @"value":                  [self convertDataToHex:[NSData dataWithBytes:&value length:sizeof(value)]],
+        @"value":                  [NSData dataWithBytes:&value length:sizeof(value)],
         @"success":                @(error == nil),
         @"error_string":           error ? [error localizedDescription] : @"success",
         @"error_code":             error ? @(error.code) : @(0),
@@ -1561,7 +1561,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         @"secondary_service_uuid": pair.secondary ? [pair.secondary.UUID uuidStr] : [NSNull null],
         @"characteristic_uuid":    [descriptor.characteristic.UUID uuidStr],
         @"descriptor_uuid":        [descriptor.UUID uuidStr],
-        @"value":                  [self convertDataToHex:data],
+        @"value":                  data,
         @"success":                @(error == nil),
         @"error_string":           error ? [error localizedDescription] : @"success",
         @"error_code":             error ? @(error.code) : @(0),
@@ -1596,7 +1596,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
     // what data did we write?
     NSString *key = [NSString stringWithFormat:@"%@:%@:%@:%@", remoteId, serviceUuid, characteristicUuid, descriptorUuid];
-    NSString *value = self.writeChrs[key] ? self.writeChrs[key] : @"";
+    NSData *value = self.writeChrs[key] ? self.writeChrs[key] : [NSMutableData data];
     [self.writeDescs removeObjectForKey:key];
     
     // See BmDescriptorData
@@ -1760,10 +1760,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
         // trim off first 2 bytes
         NSData* trimmed = [manufData subdataWithRange:NSMakeRange(2, manufData.length - 2)];
-        NSString* hex = [self convertDataToHex:trimmed];
         
         manufDataB = @{
-            @(manufId): hex,
+            @(manufId): trimmed,
         };
     }
     
@@ -1783,8 +1782,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     {
         NSMutableDictionary *mutable = [[NSMutableDictionary alloc] init];
         for (CBUUID *uuid in serviceData) {
-            NSString* hex = [self convertDataToHex:serviceData[uuid]];
-            [mutable setObject:hex forKey:[uuid uuidStr]];
+            NSData *data = serviceData[uuid];
+            [mutable setObject:data forKey:[uuid uuidStr]];
         }
         serviceDataB = [mutable copy];
     }
@@ -1994,9 +1993,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         return NO;
     }
     for (NSDictionary *f in filters) {
-        NSString *service                   = f[@"service"];
-        NSData *data = [self convertHexToData:f[@"data"]];
-        NSData *mask = [self convertHexToData:f[@"mask"]];
+        NSString *service = f[@"service"];
+        NSData *data      = f[@"data"];
+        NSData *mask      = f[@"mask"];
 
         // mask
         if (mask.length == 0 && data.length > 0) {
@@ -2024,9 +2023,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         return NO;
     }
     for (NSDictionary *f in filters) {
-        NSNumber *manufacturerId            = f[@"manufacturer_id"];
-        NSData *data = [self convertHexToData:f[@"data"]];
-        NSData *mask = [self convertHexToData:f[@"mask"]];
+        NSNumber *manufacturerId = f[@"manufacturer_id"];
+        NSData *data             = f[@"data"];
+        NSData *mask             = f[@"mask"];
 
         // first 2 bytes are manufacturer id
         unsigned short mId = 0;
@@ -2068,40 +2067,6 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     }
     
     return YES;
-}
-
-- (NSString *)convertDataToHex:(NSData *)data 
-{
-    if (data == nil) {
-        return @"";
-    }
-
-    const unsigned char *bytes = (const unsigned char *)[data bytes];
-    NSMutableString *hexString = [NSMutableString new];
-
-    for (NSInteger i = 0; i < data.length; i++) {
-        [hexString appendFormat:@"%02x", bytes[i]];
-    }
-
-    return [hexString copy];
-}
-
-- (NSData *)convertHexToData:(NSString *)hexString
-{
-    if (hexString.length % 2 != 0) {
-        return nil;
-    }
-
-    NSMutableData *data = [NSMutableData new];
-
-    for (NSInteger i = 0; i < hexString.length; i += 2) {
-        unsigned int byte = 0;
-        NSRange range = NSMakeRange(i, 2);
-        [[NSScanner scannerWithString:[hexString substringWithRange:range]] scanHexInt:&byte];
-        [data appendBytes:&byte length:1];
-    }
-
-    return [data copy];
 }
 
 - (NSString *)cbManagerStateString:(CBManagerState)adapterState

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -46,9 +46,9 @@ class BluetoothCharacteristic {
   ///   - anytime `write()` is called
   ///   - anytime a notification arrives (if subscribed)
   ///   - when the device is disconnected it is cleared
-  List<int> get lastValue {
+  Uint8List get lastValue {
     String key = "$serviceUuid:$characteristicUuid";
-    return FlutterBluePlus._lastChrs[remoteId]?[key] ?? [];
+    return FlutterBluePlus._lastChrs[remoteId]?[key] ?? Uint8List(0);
   }
 
   /// this stream emits values:
@@ -56,7 +56,7 @@ class BluetoothCharacteristic {
   ///   - anytime `write()` is called
   ///   - anytime a notification arrives (if subscribed)
   ///   - and when first listened to, it re-emits the last value for convenience
-  Stream<List<int>> get lastValueStream => FlutterBluePlus._methodStream.stream
+  Stream<Uint8List> get lastValueStream => FlutterBluePlus._methodStream.stream
       .where((m) => m.method == "OnCharacteristicReceived" || m.method == "OnCharacteristicWritten")
       .map((m) => m.arguments)
       .map((args) => BmCharacteristicData.fromMap(args))
@@ -70,7 +70,7 @@ class BluetoothCharacteristic {
   /// this stream emits values:
   ///   - anytime `read()` is called
   ///   - anytime a notification arrives (if subscribed)
-  Stream<List<int>> get onValueReceived => FlutterBluePlus._methodStream.stream
+  Stream<Uint8List> get onValueReceived => FlutterBluePlus._methodStream.stream
       .where((m) => m.method == "OnCharacteristicReceived")
       .map((m) => m.arguments)
       .map((args) => BmCharacteristicData.fromMap(args))
@@ -93,7 +93,7 @@ class BluetoothCharacteristic {
   }
 
   /// read a characteristic
-  Future<List<int>> read({int timeout = 15}) async {
+  Future<Uint8List> read({int timeout = 15}) async {
     // check connected
     if (device.isDisconnected) {
       throw FlutterBluePlusException(
@@ -105,7 +105,7 @@ class BluetoothCharacteristic {
     await mtx.take();
 
     // return value
-    List<int> responseValue = [];
+    Uint8List responseValue = Uint8List(0);
 
     try {
       var request = BmReadCharacteristicRequest(
@@ -150,7 +150,7 @@ class BluetoothCharacteristic {
   }
 
   /// Writes a characteristic.
-  ///  - [withoutResponse]: 
+  ///  - [withoutResponse]:
   ///       If `true`, the write is not guaranteed and always returns immediately with success.
   ///       If `false`, the write returns error on failure.
   ///  - [allowLongWrite]: if set, larger writes > MTU are allowed (up to 512 bytes).
@@ -159,7 +159,7 @@ class BluetoothCharacteristic {
   ///         2. the peripheral device must support the 'long write' ble protocol.
   ///         3. Interrupted transfers can leave the characteristic in a partially written state
   ///         4. If the mtu is small, it is very very slow.
-  Future<void> write(List<int> value,
+  Future<void> write(Uint8List value,
       {bool withoutResponse = false, bool allowLongWrite = false, int timeout = 15}) async {
     //  check args
     if (withoutResponse && allowLongWrite) {
@@ -321,10 +321,10 @@ class BluetoothCharacteristic {
   DeviceIdentifier get deviceId => remoteId;
 
   @Deprecated('Use lastValueStream instead')
-  Stream<List<int>> get value => lastValueStream;
+  Stream<Uint8List> get value => lastValueStream;
 
   @Deprecated('Use onValueReceived instead')
-  Stream<List<int>> get onValueChangedStream => onValueReceived;
+  Stream<Uint8List> get onValueChangedStream => onValueReceived;
 }
 
 class CharacteristicProperties {

--- a/lib/src/bluetooth_descriptor.dart
+++ b/lib/src/bluetooth_descriptor.dart
@@ -33,16 +33,16 @@ class BluetoothDescriptor {
   ///   - anytime `read()` is called
   ///   - anytime `write()` is called
   ///   - when the device is disconnected it is cleared
-  List<int> get lastValue {
+  Uint8List get lastValue {
     String key = "$serviceUuid:$characteristicUuid:$descriptorUuid";
-    return FlutterBluePlus._lastDescs[remoteId]?[key] ?? [];
+    return FlutterBluePlus._lastDescs[remoteId]?[key] ?? Uint8List(0);
   }
 
   /// this stream emits values:
   ///   - anytime `read()` is called
   ///   - anytime `write()` is called
   ///   - and when first listened to, it re-emits the last value for convenience
-  Stream<List<int>> get lastValueStream => FlutterBluePlus._methodStream.stream
+  Stream<Uint8List> get lastValueStream => FlutterBluePlus._methodStream.stream
       .where((m) => m.method == "OnDescriptorRead" || m.method == "OnDescriptorWritten")
       .map((m) => m.arguments)
       .map((args) => BmDescriptorData.fromMap(args))
@@ -56,7 +56,7 @@ class BluetoothDescriptor {
 
   /// this stream emits values:
   ///   - anytime `read()` is called
-  Stream<List<int>> get onValueReceived => FlutterBluePlus._methodStream.stream
+  Stream<Uint8List> get onValueReceived => FlutterBluePlus._methodStream.stream
       .where((m) => m.method == "OnDescriptorRead")
       .map((m) => m.arguments)
       .map((args) => BmDescriptorData.fromMap(args))
@@ -68,7 +68,7 @@ class BluetoothDescriptor {
       .map((p) => p.value);
 
   /// Retrieves the value of a specified descriptor
-  Future<List<int>> read({int timeout = 15}) async {
+  Future<Uint8List> read({int timeout = 15}) async {
     // check connected
     if (device.isDisconnected) {
       throw FlutterBluePlusException(
@@ -80,7 +80,7 @@ class BluetoothDescriptor {
     await mtx.take();
 
     // return value
-    List<int> readValue = [];
+    Uint8List readValue = Uint8List(0);
 
     try {
       var request = BmReadDescriptorRequest(
@@ -126,7 +126,7 @@ class BluetoothDescriptor {
   }
 
   /// Writes the value of a descriptor
-  Future<void> write(List<int> value, {int timeout = 15}) async {
+  Future<void> write(Uint8List value, {int timeout = 15}) async {
     // check connected
     if (device.isDisconnected) {
       throw FlutterBluePlusException(
@@ -191,7 +191,7 @@ class BluetoothDescriptor {
   }
 
   @Deprecated('Use onValueReceived instead')
-  Stream<List<int>> get value => onValueReceived;
+  Stream<Uint8List> get value => onValueReceived;
 
   @Deprecated('Use remoteId instead')
   DeviceIdentifier get deviceId => remoteId;

--- a/lib/src/bluetooth_events.dart
+++ b/lib/src/bluetooth_events.dart
@@ -189,7 +189,7 @@ class OnCharacteristicReceivedEvent {
       secondaryServiceUuid: _response.secondaryServiceUuid);
 
   /// the new data
-  List<int> get value => _response.value;
+  Uint8List get value => _response.value;
 
   /// failed?
   FbpError? get error => _response.success ? null : FbpError(_response.errorCode, _response.errorString);
@@ -212,7 +212,7 @@ class OnCharacteristicWrittenEvent {
       secondaryServiceUuid: _response.secondaryServiceUuid);
 
   /// the new data
-  List<int> get value => _response.value;
+  Uint8List get value => _response.value;
 
   /// failed?
   FbpError? get error => _response.success ? null : FbpError(_response.errorCode, _response.errorString);
@@ -235,7 +235,7 @@ class OnDescriptorReadEvent {
       descriptorUuid: _response.descriptorUuid);
 
   /// the new data
-  List<int> get value => _response.value;
+  Uint8List get value => _response.value;
 
   /// failed?
   FbpError? get error => _response.success ? null : FbpError(_response.errorCode, _response.errorString);
@@ -258,7 +258,7 @@ class OnDescriptorWrittenEvent {
       descriptorUuid: _response.descriptorUuid);
 
   /// the new data
-  List<int> get value => _response.value;
+  Uint8List get value => _response.value;
 
   /// failed?
   FbpError? get error => _response.success ? null : FbpError(_response.errorCode, _response.errorString);

--- a/lib/src/bluetooth_msgs.dart
+++ b/lib/src/bluetooth_msgs.dart
@@ -30,28 +30,28 @@ class BmBluetoothAdapterState {
 
 class BmMsdFilter {
   int manufacturerId;
-  List<int>? data;
-  List<int>? mask;
+  Uint8List? data;
+  Uint8List? mask;
   BmMsdFilter(this.manufacturerId, this.data, this.mask);
   Map<dynamic, dynamic> toMap() {
     final Map<dynamic, dynamic> map = {};
     map['manufacturer_id'] = manufacturerId;
-    map['data'] = _hexEncode(data ?? []);
-    map['mask'] = _hexEncode(mask ?? []);
+    map['data'] = data ?? [];
+    map['mask'] = mask ?? [];
     return map;
   }
 }
 
 class BmServiceDataFilter {
   Guid service;
-  List<int> data;
-  List<int> mask;
+  Uint8List data;
+  Uint8List mask;
   BmServiceDataFilter(this.service, this.data, this.mask);
   Map<dynamic, dynamic> toMap() {
     final Map<dynamic, dynamic> map = {};
     map['service'] = service.str;
-    map['data'] = _hexEncode(data);
-    map['mask'] = _hexEncode(mask);
+    map['data'] = data;
+    map['mask'] = mask;
     return map;
   }
 }
@@ -107,8 +107,8 @@ class BmScanAdvertisement {
   final bool connectable;
   final int? txPowerLevel;
   final int? appearance; // not supported on iOS / macOS
-  final Map<int, List<int>> manufacturerData;
-  final Map<Guid, List<int>> serviceData;
+  final Map<int, Uint8List> manufacturerData;
+  final Map<Guid, Uint8List> serviceData;
   final List<Guid> serviceUuids;
   final int rssi;
 
@@ -127,27 +127,18 @@ class BmScanAdvertisement {
 
   factory BmScanAdvertisement.fromMap(Map<dynamic, dynamic> json) {
     // Get raw data
-    var rawManufacturerData = json['manufacturer_data'] ?? {};
-    var rawServiceData = json['service_data'] ?? {};
-    var rawServiceUuids = json['service_uuids'] ?? [];
+    var rawManufacturerData = json['manufacturer_data'] ?? <int, Uint8List>{};
+    var rawServiceData = json['service_data'] ?? <int, Uint8List>{};
+    var rawServiceUuids = json['service_uuids'] ?? <String>[];
 
     // Cast the data to the right type
-    Map<int, List<int>> manufacturerData = {};
-    for (var key in rawManufacturerData.keys) {
-      manufacturerData[key] = _hexDecode(rawManufacturerData[key]);
-    }
+    Map<int, Uint8List> manufacturerData = rawManufacturerData.cast<int, Uint8List>();
 
     // Cast the data to the right type
-    Map<Guid, List<int>> serviceData = {};
-    for (var key in rawServiceData.keys) {
-      serviceData[Guid(key)] = _hexDecode(rawServiceData[key]);
-    }
+    Map<Guid, Uint8List> serviceData = rawServiceData.cast<Guid, Uint8List>();
 
     // Cast the data to the right type
-    List<Guid> serviceUuids = [];
-    for (var val in rawServiceUuids) {
-      serviceUuids.add(Guid(val));
-    }
+    List<Guid> serviceUuids = rawServiceUuids.map((e) => Guid(e)).toList();
 
     return BmScanAdvertisement(
       remoteId: DeviceIdentifier(json['remote_id']),
@@ -452,7 +443,7 @@ class BmCharacteristicData {
   final Guid serviceUuid;
   final Guid? secondaryServiceUuid;
   final Guid characteristicUuid;
-  final List<int> value;
+  final Uint8List value;
   final bool success;
   final int errorCode;
   final String errorString;
@@ -474,7 +465,7 @@ class BmCharacteristicData {
       serviceUuid: Guid(json['service_uuid']),
       secondaryServiceUuid: json['secondary_service_uuid'] != null ? Guid(json['secondary_service_uuid']) : null,
       characteristicUuid: Guid(json['characteristic_uuid']),
-      value: _hexDecode(json['value']),
+      value: json['value'],
       success: json['success'] != 0,
       errorCode: json['error_code'],
       errorString: json['error_string'],
@@ -520,7 +511,7 @@ class BmWriteCharacteristicRequest {
   final Guid characteristicUuid;
   final BmWriteType writeType;
   final bool allowLongWrite;
-  final List<int> value;
+  final Uint8List value;
 
   BmWriteCharacteristicRequest({
     required this.remoteId,
@@ -540,7 +531,7 @@ class BmWriteCharacteristicRequest {
     data['characteristic_uuid'] = characteristicUuid.str;
     data['write_type'] = writeType.index;
     data['allow_long_write'] = allowLongWrite ? 1 : 0;
-    data['value'] = _hexEncode(value);
+    data['value'] = value;
     return data;
   }
 }
@@ -551,7 +542,7 @@ class BmWriteDescriptorRequest {
   final Guid? secondaryServiceUuid;
   final Guid characteristicUuid;
   final Guid descriptorUuid;
-  final List<int> value;
+  final Uint8List value;
 
   BmWriteDescriptorRequest({
     required this.remoteId,
@@ -569,7 +560,7 @@ class BmWriteDescriptorRequest {
     data['secondary_service_uuid'] = secondaryServiceUuid?.str;
     data['characteristic_uuid'] = characteristicUuid.str;
     data['descriptor_uuid'] = descriptorUuid.str;
-    data['value'] = _hexEncode(value);
+    data['value'] = value;
     return data;
   }
 }
@@ -580,7 +571,7 @@ class BmDescriptorData {
   final Guid? secondaryServiceUuid;
   final Guid characteristicUuid;
   final Guid descriptorUuid;
-  final List<int> value;
+  final Uint8List value;
   final bool success;
   final int errorCode;
   final String errorString;
@@ -604,7 +595,7 @@ class BmDescriptorData {
       secondaryServiceUuid: json['secondary_service_uuid'] != null ? Guid(json['secondary_service_uuid']) : null,
       characteristicUuid: Guid(json['characteristic_uuid']),
       descriptorUuid: Guid(json['descriptor_uuid']),
-      value: _hexDecode(json['value']),
+      value: json['value'],
       success: json['success'] != 0,
       errorCode: json['error_code'],
       errorString: json['error_string'],

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -25,8 +25,8 @@ class FlutterBluePlus {
   static final Map<DeviceIdentifier, BmMtuChangedResponse> _mtuValues = {};
   static final Map<DeviceIdentifier, String> _platformNames = {};
   static final Map<DeviceIdentifier, String> _advNames = {};
-  static final Map<DeviceIdentifier, Map<String, List<int>>> _lastChrs = {};
-  static final Map<DeviceIdentifier, Map<String, List<int>>> _lastDescs = {};
+  static final Map<DeviceIdentifier, Map<String, Uint8List>> _lastChrs = {};
+  static final Map<DeviceIdentifier, Map<String, Uint8List>> _lastDescs = {};
   static final Map<DeviceIdentifier, List<StreamSubscription>> _deviceSubscriptions = {};
   static final Map<DeviceIdentifier, List<StreamSubscription>> _delayedSubscriptions = {};
   static final Map<DeviceIdentifier, DateTime> _connectTimestamp = {};
@@ -689,14 +689,14 @@ class MsdFilter {
   int manufacturerId;
 
   /// filter for this data
-  List<int> data;
+  Uint8List data;
 
   /// For any bit in the mask, set it the 1 if it needs to match
   /// the one in manufacturer data, otherwise set it to 0.
   /// The 'mask' must have the same length as 'data'.
-  List<int> mask;
+  Uint8List mask;
 
-  MsdFilter(this.manufacturerId, {this.data = const [], this.mask = const []});
+  MsdFilter(this.manufacturerId, {required this.data, required this.mask});
 
   // convert to bmMsg
   BmMsdFilter get _bm {
@@ -709,14 +709,14 @@ class ServiceDataFilter {
   Guid service;
 
   // filter for this data
-  List<int> data;
+  Uint8List data;
 
   // For any bit in the mask, set it the 1 if it needs to match
   // the one in service data, otherwise set it to 0.
   // The 'mask' must have the same length as 'data'.
-  List<int> mask;
+  Uint8List mask;
 
-  ServiceDataFilter(this.service, {this.data = const [], this.mask = const []});
+  ServiceDataFilter(this.service, {required this.data, required this.mask});
 
   // convert to bmMsg
   BmServiceDataFilter get _bm {
@@ -784,15 +784,15 @@ class AdvertisementData {
   final int? txPowerLevel;
   final int? appearance; // not supported on iOS / macOS
   final bool connectable;
-  final Map<int, List<int>> manufacturerData; // key: manufacturerId
-  final Map<Guid, List<int>> serviceData; // key: service guid
+  final Map<int, Uint8List> manufacturerData; // key: manufacturerId
+  final Map<Guid, Uint8List> serviceData; // key: service guid
   final List<Guid> serviceUuids;
 
   /// raw manufacturer specific data
-  List<List<int>> get msd {
-    List<List<int>> out = [];
+  List<Uint8List> get msd {
+    List<Uint8List> out = [];
     manufacturerData.forEach((key, value) {
-      out.add([key & 0xFF, (key >> 8) & 0xFF] + value);
+      out.add(Uint8List.fromList([key & 0xFF, (key >> 8) & 0xFF] + value));
     });
     return out;
   }

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -6,9 +6,9 @@ part of flutter_blue_plus;
 
 // Supports 16-bit, 32-bit, or 128-bit UUIDs
 class Guid {
-  final List<int> bytes;
+  final Uint8List bytes;
 
-  Guid.empty() : bytes = List.filled(16, 0);
+  Guid.empty() : bytes = Uint8List(16);
 
   Guid.fromBytes(this.bytes) : assert(_checkLen(bytes.length), 'GUID must be 16, 32, or 128 bit.');
 
@@ -16,14 +16,14 @@ class Guid {
 
   Guid(String input) : bytes = _fromString(input);
 
-  static List<int> _fromString(String input) {
+  static Uint8List _fromString(String input) {
     if (input.isEmpty) {
-      return List.filled(16, 0);
+      return Guid.empty().bytes;
     }
 
     input = input.replaceAll('-', '');
 
-    List<int>? bytes = _tryHexDecode(input);
+    Uint8List? bytes = _tryHexDecode(input);
     if (bytes == null) {
       throw FormatException("GUID not hex format: $input");
     }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,28 +1,18 @@
 part of flutter_blue_plus;
 
-String _hexEncode(List<int> numbers) {
+String _hexEncode(Uint8List numbers) {
   return numbers.map((n) => (n & 0xFF).toRadixString(16).padLeft(2, '0')).join();
 }
 
-List<int>? _tryHexDecode(String hex) {
-  List<int> numbers = [];
+Uint8List? _tryHexDecode(String hex) {
+  Uint8List numbers = Uint8List(hex.length ~/ 2);
   for (int i = 0; i < hex.length; i += 2) {
     String hexPart = hex.substring(i, i + 2);
     int? num = int.tryParse(hexPart, radix: 16);
     if (num == null) {
       return null;
     }
-    numbers.add(num);
-  }
-  return numbers;
-}
-
-List<int> _hexDecode(String hex) {
-  List<int> numbers = [];
-  for (int i = 0; i < hex.length; i += 2) {
-    String hexPart = hex.substring(i, i + 2);
-    int num = int.parse(hexPart, radix: 16);
-    numbers.add(num);
+    numbers[i ~/ 2] = num;
   }
   return numbers;
 }
@@ -250,10 +240,9 @@ class _NewStreamWithInitialValueTransformer<T> extends StreamTransformerBase<T, 
   }
 
   Stream<T> _bind(Stream<T> stream, {bool broadcast = false}) {
-
     /////////////////////////////////////////
     /// Original Stream Subscription Callbacks
-    /// 
+    ///
 
     /// When the original stream emits data, forward it to our new stream
     void onData(T data) {
@@ -291,22 +280,22 @@ class _NewStreamWithInitialValueTransformer<T> extends StreamTransformerBase<T, 
 
     //////////////////////////////////////
     ///  New Stream Controller Callbacks
-    /// 
+    ///
 
     /// (Single Subscription Only) When a client pauses
-    /// the new stream, pause the original stream 
+    /// the new stream, pause the original stream
     void onPause() {
       subscription.pause();
     }
 
     /// (Single Subscription Only) When a client resumes
-    /// the new stream, resume the original stream 
+    /// the new stream, resume the original stream
     void onResume() {
       subscription.resume();
     }
 
-    /// Called when a client cancels their 
-    /// subscription to the new stream, 
+    /// Called when a client cancels their
+    /// subscription to the new stream,
     void onCancel() {
       // count listeners of the new stream
       listenerCount--;
@@ -322,7 +311,7 @@ class _NewStreamWithInitialValueTransformer<T> extends StreamTransformerBase<T, 
 
     //////////////////////////////////////
     /// Return New Stream
-    /// 
+    ///
 
     // create a new stream controller
     if (broadcast) {


### PR DESCRIPTION
## Purpose

Using [`Uint8List`](https://api.flutter.dev/flutter/dart-typed_data/Uint8List-class.html) to pass the value as proposed in #954.

## Why?

To avoid converting between strings and byte lists. There are also several benefits shown in this [video](https://www.youtube.com/watch?v=9lhN5QXyZQc).

## Tests

I've tested this on Android, and it works as expected, but I haven't tested it on iOS (I don't have a physical device).

## Breaking changes

We can easily convert between `Uint8List` and `List<int>`:

```dart
final v = <int>[1, 2, 3];
print(v.join(',')); // 1,2,3
final vv = Uint8List.fromList(v);
print(vv.join(',')); // 1,2,3
final vvv = vv as List<int>;
print(vvv.join(',')); // 1,2,3
```

However, this is still a breaking change. How can we make the migration painless? We could provide a value8 in the property and deprecated getter of value8, for example:

```dart
class BmDescriptorData {
  final Uint8List value8;

  factory BmDescriptorData.fromMap(Map<dynamic, dynamic> json) {
    return BmDescriptorData(
      value8: json['value'],
      // ...
    );
  }

  // @deprecate
  List<int> get value => value8 as List<int>;
}
```

But I'm not sure whether we should offer this migration path or simply bump the major version.