### PR TITLE
[Fix] iOS: crash caused by 1-byte advertisements

### DIFF
--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -2020,7 +2020,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 - (BOOL)foundMsd:(NSArray<NSDictionary*>*)filters
               msd:(NSData *)msd
 {
-    if (msd == nil || msd.length == 0) {
+    if (msd == nil || msd.length < 2) {
         return NO;
     }
     for (NSDictionary *f in filters) {


### PR DESCRIPTION
Our app was crashing when a nearby device advertised with only 1 byte of data. This was due to the assumption that the first two bytes always contained the manufacturer ID. This fix prevents going to a negative index causing the app to crash completely.

<img width="1711" alt="Screenshot 2024-10-17 at 13 18 30" src="https://github.com/user-attachments/assets/a3a1b982-5f62-4d20-aa56-c19b8ce52ab3">
