### PR TITLE
[Feature]: Handle time out in startScan Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,16 @@ FlutterBluePlus.cancelWhenScanComplete(subscription);
 // In your real app you should use `FlutterBluePlus.adapterState.listen` to handle all states
 await FlutterBluePlus.adapterState.where((val) => val == BluetoothAdapterState.on).first;
 
-// Start scanning w/ timeout
+// Start scanning w/ timeout and onTimeout callback if you want to do action after timeout
 // Optional: use `stopScan()` as an alternative to timeout
 await FlutterBluePlus.startScan(
   withServices:[Guid("180D")], // match any of the specified services
   withNames:["Bluno"], // *or* any of the specified names
-  timeout: Duration(seconds:15));
+  timeout: Duration(seconds:15),
+  onTimeout: () {
+    print("Scan timed out");
+  },
+);
 
 // wait for scanning to stop
 await FlutterBluePlus.isScanning.where((val) => val == false).first;

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -229,6 +229,7 @@ class FlutterBluePlus {
     List<MsdFilter> withMsd = const [],
     List<ServiceDataFilter> withServiceData = const [],
     Duration? timeout,
+    void Function()? onTimeout,
     Duration? removeIfGone,
     bool continuousUpdates = false,
     int continuousDivisor = 1,
@@ -355,7 +356,13 @@ class FlutterBluePlus {
       // Start timer *after* stream is being listened to, to make sure the
       // timeout does not fire before _scanSubscription is set
       if (timeout != null) {
-        _scanTimeout = Timer(timeout, stopScan);
+        _scanTimeout = Timer(
+          timeout,
+          () async {
+            await stopScan();
+            onTimeout?.call();
+          },
+        );
       }
     } finally {
       mtx.give();

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -65,9 +65,8 @@ class FlutterBluePlus {
   static Future<bool> get isSupported async => await _invokeMethod('isSupported');
 
   /// The current adapter state
-  static BluetoothAdapterState get adapterStateNow => _adapterStateNow != null
-      ? _bmToAdapterState(_adapterStateNow!)
-      : BluetoothAdapterState.unknown;
+  static BluetoothAdapterState get adapterStateNow =>
+      _adapterStateNow != null ? _bmToAdapterState(_adapterStateNow!) : BluetoothAdapterState.unknown;
 
   /// Return the friendly Bluetooth name of the local Bluetooth adapter
   static Future<String> get adapterName async => await _invokeMethod('getAdapterName');
@@ -113,8 +112,7 @@ class FlutterBluePlus {
     bool showPowerAlert = true,
     bool restoreState = false,
   }) async {
-    await _invokeMethod(
-        'setOptions', {"show_power_alert": showPowerAlert, "restore_state": restoreState});
+    await _invokeMethod('setOptions', {"show_power_alert": showPowerAlert, "restore_state": restoreState});
   }
 
   /// Turn on Bluetooth (Android only),
@@ -137,15 +135,11 @@ class FlutterBluePlus {
 
       // check response
       if (response.userAccepted == false) {
-        throw FlutterBluePlusException(
-            ErrorPlatform.fbp, "turnOn", FbpErrorCode.userRejected.index, "user rejected");
+        throw FlutterBluePlusException(ErrorPlatform.fbp, "turnOn", FbpErrorCode.userRejected.index, "user rejected");
       }
 
       // wait for adapter to turn on
-      await adapterState
-          .where((s) => s == BluetoothAdapterState.on)
-          .first
-          .fbpTimeout(timeout, "turnOn");
+      await adapterState.where((s) => s == BluetoothAdapterState.on).first.fbpTimeout(timeout, "turnOn");
     }
   }
 
@@ -181,8 +175,7 @@ class FlutterBluePlus {
   /// - You must still call device.connect() to connect them to *your app*
   /// - [withServices] required on iOS (for privacy purposes). ignored on android.
   static Future<List<BluetoothDevice>> systemDevices(List<Guid> withServices) async {
-    var result = await _invokeMethod(
-        'getSystemDevices', {"with_services": withServices.map((s) => s.str).toList()});
+    var result = await _invokeMethod('getSystemDevices', {"with_services": withServices.map((s) => s.str).toList()});
     var r = BmDevicesList.fromMap(result);
     for (BmBluetoothDevice device in r.devices) {
       if (device.platformName != null) {
@@ -237,7 +230,6 @@ class FlutterBluePlus {
     List<ServiceDataFilter> withServiceData = const [],
     Duration? timeout,
     Duration? removeIfGone,
-    void Function()? onTimeout,
     bool continuousUpdates = false,
     int continuousDivisor = 1,
     bool oneByOne = false,
@@ -318,15 +310,13 @@ class FlutterBluePlus {
       _scanSubscription = outputStream.listen((BmScanResponse? response) {
         if (response == null) {
           // if null, this is just a periodic update to remove old results
-          if (output
-              ._removeWhere((elm) => DateTime.now().difference(elm.timeStamp) > removeIfGone!)) {
+          if (output._removeWhere((elm) => DateTime.now().difference(elm.timeStamp) > removeIfGone!)) {
             _scanResults.add(List.from(output)); // push to stream
           }
         } else {
           // failure?
           if (response.success == false) {
-            var e = FlutterBluePlusException(
-                _nativeError, "scan", response.errorCode, response.errorString);
+            var e = FlutterBluePlusException(_nativeError, "scan", response.errorCode, response.errorString);
             _scanResults.addError(e);
             _stopScan(invokePlatform: false);
           }
@@ -365,13 +355,7 @@ class FlutterBluePlus {
       // Start timer *after* stream is being listened to, to make sure the
       // timeout does not fire before _scanSubscription is set
       if (timeout != null) {
-        _scanTimeout = Timer(
-          timeout,
-          () async {
-           await stopScan();
-           onTimeout?.call();
-          },
-        );
+        _scanTimeout = Timer(timeout, stopScan);
       }
     } finally {
       mtx.give();
@@ -587,8 +571,7 @@ class FlutterBluePlus {
       var r = BmDescriptorData.fromMap(call.arguments);
       if (r.success == true) {
         _lastDescs[r.remoteId] ??= {};
-        _lastDescs[r.remoteId]!["${r.serviceUuid}:${r.characteristicUuid}:${r.descriptorUuid}"] =
-            r.value;
+        _lastDescs[r.remoteId]!["${r.serviceUuid}:${r.characteristicUuid}:${r.descriptorUuid}"] = r.value;
       }
     }
 
@@ -658,8 +641,7 @@ class FlutterBluePlus {
   /// Turn off Bluetooth (Android only),
   @Deprecated('Deprecated in Android SDK 33 with no replacement')
   static Future<void> turnOff({int timeout = 10}) async {
-    Stream<BluetoothAdapterState> responseStream =
-        adapterState.where((s) => s == BluetoothAdapterState.off);
+    Stream<BluetoothAdapterState> responseStream = adapterState.where((s) => s == BluetoothAdapterState.off);
 
     // Start listening now, before invokeMethod, to ensure we don't miss the response
     Future<BluetoothAdapterState> futureResponse = responseStream.first;
@@ -715,7 +697,6 @@ enum LogLevel {
 
 class AndroidScanMode {
   const AndroidScanMode(this.value);
-
   static const lowPower = AndroidScanMode(0);
   static const balanced = AndroidScanMode(1);
   static const lowLatency = AndroidScanMode(2);
@@ -765,7 +746,6 @@ class ServiceDataFilter {
 
 class DeviceIdentifier {
   final String str;
-
   const DeviceIdentifier(this.str);
 
   @override
@@ -775,8 +755,7 @@ class DeviceIdentifier {
   int get hashCode => str.hashCode;
 
   @override
-  bool operator ==(other) =>
-      other is DeviceIdentifier && _compareAsciiLowerCase(str, other.str) == 0;
+  bool operator ==(other) => other is DeviceIdentifier && _compareAsciiLowerCase(str, other.str) == 0;
 
   @Deprecated('Use str instead')
   String get id => str;
@@ -803,8 +782,7 @@ class ScanResult {
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ScanResult && runtimeType == other.runtimeType && device == other.device;
+      identical(this, other) || other is ScanResult && runtimeType == other.runtimeType && device == other.device;
 
   @override
   int get hashCode => device.hashCode;


### PR DESCRIPTION
This pull request introduces an optional onTimeout parameter to the startScan method. The onTimeout callback function is triggered in the stopScan method when the scan times out, providing user a way to handle timeout events directly.

**Changes**

- Added void Function()? onTimeout as an optional parameter to startScan.
- Updated _scanTimeout in stopScan to invoke onTimeout?.call() after the scan stops due to a timeout.

**Benefit**

This improvement allows developers to handle timeout events with a custom callback, increasing flexibility and control over scan behavior.

**Testing**

I have tested the changes, and the functionality is working as expected. The onTimeout callback is triggered correctly upon timeout.