### PR TITLE
distinguish between read and notification for future completion

### DIFF
--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -2279,7 +2279,7 @@ public class FlutterBluePlusPlugin implements
         }
 
         // called for both notifications & reads
-        public void onCharacteristicReceived(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, int status)
+        public void onCharacteristicReceived(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, int status, boolean fromReadOperation)
         {
             // GATT Service?
             if (uuidStr(characteristic.getService().getUuid()) == "1800") {
@@ -2306,6 +2306,7 @@ public class FlutterBluePlusPlugin implements
             if (primaryService != null) {
                 response.put("primary_service_uuid", uuidStr(primaryService.getUuid()));
             }
+            response.put("from_read_operation", fromReadOperation ? 1 : 0);
 
             invokeMethodUIThread("OnCharacteristicReceived", response);
         }
@@ -2318,7 +2319,7 @@ public class FlutterBluePlusPlugin implements
             LogLevel level = LogLevel.DEBUG;
             log(level, "onCharacteristicChanged:");
             log(level, "  chr: " + uuidStr(characteristic.getUuid()));
-            onCharacteristicReceived(gatt, characteristic, value, BluetoothGatt.GATT_SUCCESS);
+            onCharacteristicReceived(gatt, characteristic, value, BluetoothGatt.GATT_SUCCESS, false);
         }
 
         @Override
@@ -2330,7 +2331,7 @@ public class FlutterBluePlusPlugin implements
             log(level, "onCharacteristicRead:");
             log(level, "  chr: " + uuidStr(characteristic.getUuid()));
             log(level, "  status: " + gattErrorString(status) + " (" + status + ")");
-            onCharacteristicReceived(gatt, characteristic, value, status);
+            onCharacteristicReceived(gatt, characteristic, value, status, true);
         }
 
         @Override

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -1441,6 +1441,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         @"success":                     error == nil ? @(1) : @(0),
         @"error_string":                error ? [error localizedDescription] : @"success",
         @"error_code":                  error ? @(error.code) : @(0),
+        // TODO: How to determine this on iOS / macOS?
+        @"from_read_operation":         @(1),
     } mutableCopy];
 
     // remove if null

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -124,7 +124,8 @@ class BluetoothCharacteristic {
           .where((p) => p.remoteId == request.remoteId)
           .where((p) => p.serviceUuid == request.serviceUuid)
           .where((p) => p.characteristicUuid == request.characteristicUuid)
-          .where((p) => p.primaryServiceUuid == request.primaryServiceUuid);
+          .where((p) => p.primaryServiceUuid == request.primaryServiceUuid)
+          .where((p) => p.fromReadOperation == true);
 
       // Start listening now, before invokeMethod, to ensure we don't miss the response
       Future<BmCharacteristicData> futureResponse = responseStream.first;

--- a/lib/src/bluetooth_msgs.dart
+++ b/lib/src/bluetooth_msgs.dart
@@ -452,6 +452,7 @@ class BmCharacteristicData {
   final bool success;
   final int errorCode;
   final String errorString;
+  final bool fromReadOperation;
 
 
   BmCharacteristicData({
@@ -463,6 +464,7 @@ class BmCharacteristicData {
     required this.success,
     required this.errorCode,
     required this.errorString,
+    required this.fromReadOperation,
   });
 
   factory BmCharacteristicData.fromMap(Map<dynamic, dynamic> json) {
@@ -475,6 +477,7 @@ class BmCharacteristicData {
       success: json['success'] != 0,
       errorCode: json['error_code'],
       errorString: json['error_string'],
+      fromReadOperation: json.containsKey('from_read_operation') && (json['from_read_operation'] != 0),
     );
   }
 }


### PR DESCRIPTION
Hi, I have run into an issue with flutter_blue_plus when I enable notifications for a characteristic and also call read operations. You might say "there is no reason to use read operations if you are using notifications" and I would accept that answer.

However, I did some digging and saw that the completion criteria for the future in https://github.com/chipweinberger/flutter_blue_plus/blob/c195c47989b3df6f9b514d7a82bcac158cf54ce5/lib/src/bluetooth_characteristic.dart#L120 does not distinguish between the result of a read operation or a notification. Now for Android, this distinction is pretty simple to introduce, c.f. this PR. For iOS / macOS unfortunately I do not know how to do it, maybe you have a suggestion?

There are two problems that might happen when not doing this distinction:

* the read value might correspond to a notification value (harmless in all cases where the values are "stable", i.e. there is no funky distinction between read and notify logic on the other side)
* a subsequent operation might fail with a BUSY error, because the actual read has not completed, but its future was completed by the notification

For some context, I ran into this problem when doing subsequent calls to setNotifyValue() and read(), here is the corresponding debug log:

```
I/flutter (13262): BLE: INFO: 2024-12-16 13:36:42.321029: reading characteristic 6d1a6389-697f-657e-0000-000000000000...
D/[FBP-Android](13262): [FBP] onMethodCall: readCharacteristic
D/[FBP-Android](13262): [FBP] onCharacteristicRead:
D/[FBP-Android](13262): [FBP]   chr: 6d1a6389-697f-657e-0000-000000000000
D/[FBP-Android](13262): [FBP]   status: GATT_SUCCESS (0)
I/flutter (13262): BLE: INFO: 2024-12-16 13:36:42.365419: reading characteristic 6d166384-6985-6544-0000-000000000000...
D/[FBP-Android](13262): [FBP] onMethodCall: readCharacteristic
D/[FBP-Android](13262): [FBP] onCharacteristicRead:
D/[FBP-Android](13262): [FBP]   chr: 6d166384-6985-6544-0000-000000000000
D/[FBP-Android](13262): [FBP]   status: GATT_SUCCESS (0)
I/flutter (13262): BLE: INFO: 2024-12-16 13:36:42.397289: activating notification for 6408736b-6169-637b-0000-000000000000...
D/[FBP-Android](13262): [FBP] onMethodCall: setNotifyValue
D/BluetoothGatt(13262): setCharacteristicNotification() - uuid: 6408736b-6169-637b-0000-000000000000 enable: true
D/[FBP-Android](13262): [FBP] onDescriptorWrite:
D/[FBP-Android](13262): [FBP]   chr: 6408736b-6169-637b-0000-000000000000
D/[FBP-Android](13262): [FBP]   desc: 2902
D/[FBP-Android](13262): [FBP]   status: GATT_SUCCESS (0)
I/flutter (13262): BLE: INFO: 2024-12-16 13:36:42.426312: reading characteristic 6408736b-6169-637b-0000-000000000000...
D/[FBP-Android](13262): [FBP] onMethodCall: readCharacteristic
D/[FBP-Android](13262): [FBP] onCharacteristicChanged:
D/[FBP-Android](13262): [FBP]   chr: 6408736b-6169-637b-0000-000000000000
I/flutter (13262): BLE: INFO: 2024-12-16 13:36:42.456721: activating notification for 72047478-0076-0000-0000-000000000000...
D/[FBP-Android](13262): [FBP] onMethodCall: setNotifyValue
D/BluetoothGatt(13262): setCharacteristicNotification() - uuid: 72047478-0076-0000-0000-000000000000 enable: true
W/BluetoothGatt(13262): writeDescriptor() - prior command is not finished, mClient= 5
I/flutter (13262): BLE: SEVERE: 2024-12-16 13:36:42.465226: Error activating notification for 72047478-0076-0000-0000-000000000000: gatt.writeDescriptor() returned 201 : ERROR_GATT_WRITE_REQUEST_BUSY
D/[FBP-Android](13262): [FBP] onCharacteristicRead:
D/[FBP-Android](13262): [FBP]   chr: 6408736b-6169-637b-0000-000000000000
D/[FBP-Android](13262): [FBP]   status: GATT_SUCCESS (0)
D/[FBP-Android](13262): [FBP] onCharacteristicChanged:
D/[FBP-Android](13262): [FBP]   chr: 6408736b-6169-637b-0000-000000000000
D/[FBP-Android](13262): [FBP] onCharacteristicChanged:
D/[FBP-Android](13262): [FBP]   chr: 72047478-0076-0000-0000-000000000000
D/[FBP-Android](13262): [FBP] onCharacteristicChanged:
D/[FBP-Android](13262): [FBP]   chr: 6408736b-6169-637b-0000-000000000000
D/[FBP-Android](13262): [FBP] onCharacteristicChanged:
D/[FBP-Android](13262): [FBP]   chr: 72047478-0076-0000-0000-000000000000
D/[FBP-Android](13262): [FBP] onCharacteristicChanged:
D/[FBP-Android](13262): [FBP]   chr: 6408736b-6169-637b-0000-000000000000
```