### PR TITLE
[Android] add option to provide pairing PIN to createBond

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -555,7 +555,7 @@ class BluetoothDevice {
 
   /// Force the bonding popup to show now (Android Only)
   /// Note! calling this is usually not necessary!! The platform does it automatically.
-  Future<void> createBond({int timeout = 90}) async {
+  Future<void> createBond({int timeout = 90, Uint8List? pin}) async {
     // check android
     if (kIsWeb || !Platform.isAndroid) {
       throw FlutterBluePlusException(ErrorPlatform.fbp, "createBond",
@@ -581,7 +581,7 @@ class BluetoothDevice {
       Future<BmBondStateResponse> futureResponse = responseStream.first;
 
       // invoke
-      bool changed = await FlutterBluePlus._invokeMethod(() => FlutterBluePlusPlatform.instance.createBond(BmCreateBondRequest(remoteId: remoteId)));
+      bool changed = await FlutterBluePlus._invokeMethod(() => FlutterBluePlusPlatform.instance.createBond(BmCreateBondRequest(remoteId: remoteId, pin: pin)));
 
       // only wait for 'bonded' if we weren't already bonded
       if (changed) {

--- a/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart
+++ b/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart
@@ -128,7 +128,7 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
   ) async {
     return await _invokeMethod<bool>(
       'createBond',
-      request.remoteId.str,
+      request.toMap(),
     ) == true;
   }
 

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'device_identifier.dart';
 import 'guid.dart';
 import 'log_level.dart';
@@ -877,10 +879,19 @@ class BmBondStateResponse {
 
 class BmCreateBondRequest {
   DeviceIdentifier remoteId;
+  Uint8List? pin;
 
   BmCreateBondRequest({
     required this.remoteId,
+    required this.pin,
   });
+  
+  Map<dynamic, dynamic> toMap() {
+    final Map<dynamic, dynamic> data = {};
+    data['remote_id'] = remoteId.str;
+    data['pin'] = pin;
+    return data;
+  }
 }
 
 class BmRemoveBondRequest {


### PR DESCRIPTION
Hi again,

I use flutter_blue_plus to communicate with GATT peripherals that have individual PINs. I can query the PINs from a Cloud database and show them in my app, but it would be great to enter the pairing PIN automatically if the platform allows it, which is the case on Android, not on iOS (not sure about bluez, but it probably is, even though createBond is Android-only for now).