### PR TITLE
[Web] Add support for optional services

### DIFF
--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -219,6 +219,7 @@ class FlutterBluePlus {
     bool androidLegacy = false,
     AndroidScanMode androidScanMode = AndroidScanMode.lowLatency,
     bool androidUsesFineLocation = false,
+    List<Guid> webOptionalServices = const [],
   }) async {
     // check args
     assert(removeIfGone == null || continuousUpdates, "removeIfGone requires continuousUpdates");
@@ -263,7 +264,8 @@ class FlutterBluePlus {
           continuousDivisor: continuousDivisor,
           androidLegacy: androidLegacy,
           androidScanMode: androidScanMode.value,
-          androidUsesFineLocation: androidUsesFineLocation);
+          androidUsesFineLocation: androidUsesFineLocation,
+          webOptionalServices: webOptionalServices);
 
       Stream<BmScanResponse> responseStream = FlutterBluePlusPlatform.instance.onScanResponse;
 

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -80,6 +80,7 @@ class BmScanSettings {
   final bool androidLegacy;
   final int androidScanMode;
   final bool androidUsesFineLocation;
+  final List<Guid> webOptionalServices;
 
   BmScanSettings({
     required this.withServices,
@@ -93,6 +94,7 @@ class BmScanSettings {
     required this.androidLegacy,
     required this.androidScanMode,
     required this.androidUsesFineLocation,
+    required this.webOptionalServices,
   });
 
   Map<dynamic, dynamic> toMap() {
@@ -108,6 +110,7 @@ class BmScanSettings {
     data['android_legacy'] = androidLegacy;
     data['android_scan_mode'] = androidScanMode;
     data['android_uses_fine_location'] = androidUsesFineLocation;
+    data['web_optional_services'] = webOptionalServices;
     return data;
   }
 }

--- a/packages/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
+++ b/packages/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
@@ -474,10 +474,12 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
       if (filters.length > 0) {
         options = RequestDeviceOptions(
           filters: filters.toJS,
+          optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,
         );
       } else {
         options = RequestDeviceOptions(
           acceptAllDevices: true,
+          optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,
         );
       }
 


### PR DESCRIPTION
Hey, 

In this PR I added support for [optional services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices). 
It's a required option to use device if you set no filters or you just filter by name.
More details you can find [here](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#acceptalldevices) and [here](https://webbluetoothcg.github.io/web-bluetooth/#dom-requestdeviceoptions-optionalservices) 