### PR TITLE
fix: Correct casting of raw json in BmScanAdvertisement

### DIFF
--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -151,13 +151,18 @@ class BmScanAdvertisement {
     var rawServiceUuids = json['service_uuids'] ?? [];
 
     // Cast the data to the right type
-    Map<int, List<int>> manufacturerData = rawManufacturerData.map((k, v) => MapEntry(k as int, v as Uint8List));
-
+    Map<int, List<int>> manufacturerData = {};
+    rawManufacturerData.forEach((k, v) {
+      manufacturerData[k] = v;
+    });
     // Cast the data to the right type
-    Map<Guid, List<int>> serviceData = rawServiceData.map((k, v) => MapEntry(k as Guid, v as Uint8List));
-
+    Map<Guid, List<int>> serviceData = {};
+    rawServiceData.forEach((k, v) {
+      serviceData[k] = v;
+    });
     // Cast the data to the right type
-    List<Guid> serviceUuids = rawServiceUuids.cast<String>().map((e) => Guid(e)).toList();
+    List<Guid> serviceUuids = [];
+    rawServiceUuids.forEach((e) => serviceUuids.add(e));
 
     return BmScanAdvertisement(
       remoteId: DeviceIdentifier(json['remote_id']),


### PR DESCRIPTION
Currently fails with

I/flutter ( 3579): type '_Map<dynamic, dynamic>' is not a subtype of type 'Iterable<MapEntry<int, List<int>>>'

Surprisingly, the exception is swallowed somewhere without producing logs. I found this with some trial and error.

I tried some iterations of a fix and this is the most elegant way of making it work. Tested with example app on Android. Without the fix, devices don't show up, as they don't make it to dart. Surprisingly, the exception is swallowed somewhere without producing logs.