### PR TITLE
Don't wait for CCD descriptor write for setNotifyValue on web.

### DIFF
--- a/packages/flutter_blue_plus_platform_interface/lib/flutter_blue_plus_platform_interface.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/flutter_blue_plus_platform_interface.dart
@@ -226,6 +226,8 @@ abstract base class FlutterBluePlusPlatform {
     return Future.value(false);
   }
 
+  // Returns true if callers need to wait for Client Characteristic Configuration Descriptor to be written before returning.
+  // Throws an exception on error.
   Future<bool> setNotifyValue(
     BmSetNotifyValueRequest request,
   ) {

--- a/packages/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
+++ b/packages/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
@@ -435,7 +435,7 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
       );
     }
 
-    return true;
+    return false;
   }
 
   @override


### PR DESCRIPTION
The call [bool hasCCCD = await FlutterBluePlus._invokeMethod(() => FlutterBluePlusPlatform.instance.setNotifyValue(request));](https://github.com/chipweinberger/flutter_blue_plus/blob/86a084f01fe09c0b67240521a97d1e1e6e16f4e1/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart#L260) currently returns true, leading to a timeout later when trying to wait for CCCD. This is not relevant for web platform, apparently. Jointly documenting semantics of returning true in the platform interface. Fixes #1147.