### PR TITLE
Fix exception when adapters is empty.

### DIFF
--- a/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
+++ b/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
@@ -443,7 +443,7 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
     await _initFlutterBluePlus();
 
     return BmBluetoothAdapterState(
-      adapterState: _client.adapters.first.powered
+      adapterState: _client.adapters.firstOrNull?.powered == true
           ? BmAdapterStateEnum.on
           : BmAdapterStateEnum.off,
     );


### PR DESCRIPTION
On some linux platforms, a disabled adapter is represented as missing.

Currently throws `Unhandled Exception: Bad state: No element`