### PR TITLE
Fix errorCode for createBond on iOS

### DIFF
--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -771,7 +771,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         }
         else if([@"createBond" isEqualToString:call.method])
         {
-            result([FlutterError errorWithCode:@"setPreferredPhy" 
+            result([FlutterError errorWithCode:@"createBond" 
                                     message:@"android only"
                                     details:NULL]);
         }


### PR DESCRIPTION
Seems to accidentally have been set to another method `setPreferredPhy`