### PR TITLE
fix build deprecation warnings on Android

### DIFF
--- a/packages/flutter_blue_plus/example/android/app/build.gradle
+++ b/packages/flutter_blue_plus/example/android/app/build.gradle
@@ -27,8 +27,8 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     defaultConfig {

--- a/packages/flutter_blue_plus/example/android/settings.gradle
+++ b/packages/flutter_blue_plus/example/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version '8.2.1' apply false
 }
 
 include ":app"

--- a/packages/flutter_blue_plus_android/android/build.gradle
+++ b/packages/flutter_blue_plus_android/android/build.gradle
@@ -7,8 +7,8 @@ android {
     compileSdkVersion 33
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     lintOptions {


### PR DESCRIPTION
This should fix Java 8 obsolete build warning below. The Flutter's core plugins been on Java 11 target for a while.

Verified using `flutter build appbundle` with the example app.


```
Running Gradle task 'bundleRelease'...                          
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings
```
