### PR TITLE
[Android] location services check

### DIFF
--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -230,6 +230,7 @@ class FlutterBluePlus {
     bool androidLegacy = false,
     AndroidScanMode androidScanMode = AndroidScanMode.lowLatency,
     bool androidUsesFineLocation = false,
+    bool androidCheckLocationServices = true,
     List<Guid> webOptionalServices = const [],
   }) async {
     // check args
@@ -276,6 +277,7 @@ class FlutterBluePlus {
           androidLegacy: androidLegacy,
           androidScanMode: androidScanMode.value,
           androidUsesFineLocation: androidUsesFineLocation,
+          androidCheckLocationServices: androidCheckLocationServices,
           webOptionalServices: webOptionalServices);
 
       Stream<BmScanResponse> responseStream = FlutterBluePlusPlatform.instance.onScanResponse;

--- a/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -1606,17 +1606,16 @@ public class FlutterBluePlusPlugin implements
     // Check if Android location services are enabled
     @SuppressWarnings("deprecation")
     private boolean isLocationEnabled() {
-        Activity activity = activityBinding.getActivity();
         if (Build.VERSION.SDK_INT >= 31) {
             // Android 12 (October 2021) - location services are not required for BLE scanning
             return true;
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             // This is a new method provided in API 28 / Android 9 August 2018
-            LocationManager lm = (LocationManager) activity.getSystemService(Context.LOCATION_SERVICE);
+            LocationManager lm = (LocationManager) activityBinding.getActivity().getSystemService(Context.LOCATION_SERVICE);
             return lm != null && lm.isLocationEnabled();
         } else {
             // This was deprecated in API 28
-            int mode = Settings.Secure.getInt(activity.getContentResolver(),
+            int mode = Settings.Secure.getInt(activityBinding.getActivity().getContentResolver(),
                 Settings.Secure.LOCATION_MODE, Settings.Secure.LOCATION_MODE_OFF);
             return mode != Settings.Secure.LOCATION_MODE_OFF;
         }

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -80,6 +80,7 @@ class BmScanSettings {
   final bool androidLegacy;
   final int androidScanMode;
   final bool androidUsesFineLocation;
+  final bool androidCheckLocationServices;
   final List<Guid> webOptionalServices;
 
   BmScanSettings({
@@ -94,6 +95,7 @@ class BmScanSettings {
     required this.androidLegacy,
     required this.androidScanMode,
     required this.androidUsesFineLocation,
+    required this.androidCheckLocationServices,
     required this.webOptionalServices,
   });
 
@@ -110,6 +112,7 @@ class BmScanSettings {
     data['android_legacy'] = androidLegacy;
     data['android_scan_mode'] = androidScanMode;
     data['android_uses_fine_location'] = androidUsesFineLocation;
+    data['android_check_location_services'] = androidCheckLocationServices;
     data['web_optional_services'] = webOptionalServices.map((s) => s.str).toList();;
     return data;
   }

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -95,7 +95,7 @@ class BmScanSettings {
     required this.androidLegacy,
     required this.androidScanMode,
     required this.androidUsesFineLocation,
-    required this.androidCheckLocationServices,
+    this.androidCheckLocationServices = true,
     required this.webOptionalServices,
   });
 


### PR DESCRIPTION
This should address #1192 issue.

@chipweinberger @tnc1997 what are the steps to release these changes?

Need to bump version in the platform interface. With a new attribute added should it be `4.0.1 -> 4.0.2` or we need a higher version?

Similarly for Android plugin. Is `4.0.2 -> 4.0.3` ok for a new property? And the Android plugin probably shouldn't depend on `^4.0.0` version of platform as it needs newly added properties...