### PR TITLE
Flutter lints fixes

### DIFF
--- a/packages/flutter_blue_plus/analysis_options.yaml
+++ b/packages/flutter_blue_plus/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at

--- a/packages/flutter_blue_plus/example/analysis_options.yaml
+++ b/packages/flutter_blue_plus/example/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at

--- a/packages/flutter_blue_plus/example/ios/Podfile.lock
+++ b/packages/flutter_blue_plus/example/ios/Podfile.lock
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_blue_plus_darwin: 3ea4ec9133b377febcc8a70b28cd2d2dc9242bd9
+  flutter_blue_plus_darwin: 904ed52825285a15f60e9d90312337a09f11a785
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 

--- a/packages/flutter_blue_plus/example/lib/main.dart
+++ b/packages/flutter_blue_plus/example/lib/main.dart
@@ -20,7 +20,7 @@ void main() {
 // ScanScreen depending on the adapter state
 //
 class FlutterBlueApp extends StatefulWidget {
-  const FlutterBlueApp({Key? key}) : super(key: key);
+  const FlutterBlueApp({super.key});
 
   @override
   State<FlutterBlueApp> createState() => _FlutterBlueAppState();

--- a/packages/flutter_blue_plus/example/lib/screens/bluetooth_off_screen.dart
+++ b/packages/flutter_blue_plus/example/lib/screens/bluetooth_off_screen.dart
@@ -7,7 +7,7 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import '../utils/snackbar.dart';
 
 class BluetoothOffScreen extends StatelessWidget {
-  const BluetoothOffScreen({Key? key, this.adapterState}) : super(key: key);
+  const BluetoothOffScreen({super.key, this.adapterState});
 
   final BluetoothAdapterState? adapterState;
 
@@ -22,7 +22,7 @@ class BluetoothOffScreen extends StatelessWidget {
   Widget buildTitle(BuildContext context) {
     String? state = adapterState?.toString().split(".").last;
     return Text(
-      'Bluetooth Adapter is ${state != null ? state : 'not available'}',
+      'Bluetooth Adapter is ${state ?? 'not available'}',
       style: Theme.of(context).primaryTextTheme.titleSmall?.copyWith(color: Colors.white),
     );
   }

--- a/packages/flutter_blue_plus/example/lib/screens/device_screen.dart
+++ b/packages/flutter_blue_plus/example/lib/screens/device_screen.dart
@@ -12,7 +12,7 @@ import '../utils/extra.dart';
 class DeviceScreen extends StatefulWidget {
   final BluetoothDevice device;
 
-  const DeviceScreen({Key? key, required this.device}) : super(key: key);
+  const DeviceScreen({super.key, required this.device});
 
   @override
   State<DeviceScreen> createState() => _DeviceScreenState();
@@ -205,16 +205,16 @@ class _DeviceScreenState extends State<DeviceScreen> {
       index: (_isDiscoveringServices) ? 1 : 0,
       children: <Widget>[
         TextButton(
-          child: const Text("Get Services"),
           onPressed: onDiscoverServicesPressed,
+          child: const Text("Get Services"),
         ),
         const IconButton(
           icon: SizedBox(
+            width: 18.0,
+            height: 18.0,
             child: CircularProgressIndicator(
               valueColor: AlwaysStoppedAnimation(Colors.grey),
             ),
-            width: 18.0,
-            height: 18.0,
           ),
           onPressed: null,
         )

--- a/packages/flutter_blue_plus/example/lib/screens/scan_screen.dart
+++ b/packages/flutter_blue_plus/example/lib/screens/scan_screen.dart
@@ -10,7 +10,7 @@ import '../widgets/scan_result_tile.dart';
 import '../utils/extra.dart';
 
 class ScanScreen extends StatefulWidget {
-  const ScanScreen({Key? key}) : super(key: key);
+  const ScanScreen({super.key});
 
   @override
   State<ScanScreen> createState() => _ScanScreenState();
@@ -28,18 +28,16 @@ class _ScanScreenState extends State<ScanScreen> {
     super.initState();
 
     _scanResultsSubscription = FlutterBluePlus.scanResults.listen((results) {
-      _scanResults = results;
       if (mounted) {
-        setState(() {});
+        setState(() => _scanResults = results);
       }
     }, onError: (e) {
       Snackbar.show(ABC.b, prettyException("Scan Error:", e), success: false);
     });
 
     _isScanningSubscription = FlutterBluePlus.isScanning.listen((state) {
-      _isScanning = state;
       if (mounted) {
-        setState(() {});
+        setState(() => _isScanning = state);
       }
     });
   }
@@ -64,8 +62,15 @@ class _ScanScreenState extends State<ScanScreen> {
     try {
       await FlutterBluePlus.startScan(
         timeout: const Duration(seconds: 15),
+        withServices: [
+          // Guid("180f"), // battery
+          // Guid("180a"), // device info
+          // Guid("1800"), // generic access
+          // Guid("6e400001-b5a3-f393-e0a9-e50e24dcca9e"), // Nordic UART
+        ],
         webOptionalServices: [
           Guid("180f"), // battery
+          Guid("180a"), // device info
           Guid("1800"), // generic access
           Guid("6e400001-b5a3-f393-e0a9-e50e24dcca9e"), // Nordic UART
         ],
@@ -112,12 +117,12 @@ class _ScanScreenState extends State<ScanScreen> {
   Widget buildScanButton(BuildContext context) {
     if (FlutterBluePlus.isScanningNow) {
       return FloatingActionButton(
-        child: const Icon(Icons.stop),
         onPressed: onStopPressed,
         backgroundColor: Colors.red,
+        child: const Icon(Icons.stop),
       );
     } else {
-      return FloatingActionButton(child: const Text("SCAN"), onPressed: onScanPressed);
+      return FloatingActionButton(onPressed: onScanPressed, child: const Text("SCAN"));
     }
   }
 

--- a/packages/flutter_blue_plus/example/lib/utils/utils.dart
+++ b/packages/flutter_blue_plus/example/lib/utils/utils.dart
@@ -11,7 +11,7 @@ class StreamControllerReemit<T> {
   StreamControllerReemit({T? initialValue}) : _latestValue = initialValue;
 
   Stream<T> get stream {
-    return _latestValue != null ? _controller.stream.newStreamWithInitialValue(_latestValue!) : _controller.stream;
+    return _latestValue != null ? _controller.stream.newStreamWithInitialValue(_latestValue as T) : _controller.stream;
   }
 
   T? get value => _latestValue;

--- a/packages/flutter_blue_plus/example/lib/widgets/characteristic_tile.dart
+++ b/packages/flutter_blue_plus/example/lib/widgets/characteristic_tile.dart
@@ -12,7 +12,7 @@ class CharacteristicTile extends StatefulWidget {
   final BluetoothCharacteristic characteristic;
   final List<DescriptorTile> descriptorTiles;
 
-  const CharacteristicTile({Key? key, required this.characteristic, required this.descriptorTiles}) : super(key: key);
+  const CharacteristicTile({super.key, required this.characteristic, required this.descriptorTiles});
 
   @override
   State<CharacteristicTile> createState() => _CharacteristicTileState();

--- a/packages/flutter_blue_plus/example/lib/widgets/descriptor_tile.dart
+++ b/packages/flutter_blue_plus/example/lib/widgets/descriptor_tile.dart
@@ -9,7 +9,7 @@ import "../utils/snackbar.dart";
 class DescriptorTile extends StatefulWidget {
   final BluetoothDescriptor descriptor;
 
-  const DescriptorTile({Key? key, required this.descriptor}) : super(key: key);
+  const DescriptorTile({super.key, required this.descriptor});
 
   @override
   State<DescriptorTile> createState() => _DescriptorTileState();
@@ -78,15 +78,15 @@ class _DescriptorTileState extends State<DescriptorTile> {
 
   Widget buildReadButton(BuildContext context) {
     return TextButton(
-      child: Text("Read"),
       onPressed: onReadPressed,
+      child: Text("Read"),
     );
   }
 
   Widget buildWriteButton(BuildContext context) {
     return TextButton(
-      child: Text("Write"),
       onPressed: onWritePressed,
+      child: Text("Write"),
     );
   }
 

--- a/packages/flutter_blue_plus/example/lib/widgets/scan_result_tile.dart
+++ b/packages/flutter_blue_plus/example/lib/widgets/scan_result_tile.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 class ScanResultTile extends StatefulWidget {
-  const ScanResultTile({Key? key, required this.result, this.onTap}) : super(key: key);
+  const ScanResultTile({super.key, required this.result, this.onTap});
 
   final ScanResult result;
   final VoidCallback? onTap;
@@ -41,7 +41,7 @@ class _ScanResultTileState extends State<ScanResultTile> {
   }
 
   String getNiceManufacturerData(List<List<int>> data) {
-    return data.map((val) => '${getNiceHexArray(val)}').join(', ').toUpperCase();
+    return data.map((val) => getNiceHexArray(val)).join(', ').toUpperCase();
   }
 
   String getNiceServiceData(Map<Guid, List<int>> data) {
@@ -79,12 +79,12 @@ class _ScanResultTileState extends State<ScanResultTile> {
 
   Widget _buildConnectButton(BuildContext context) {
     return ElevatedButton(
-      child: isConnected ? const Text('OPEN') : const Text('CONNECT'),
       style: ElevatedButton.styleFrom(
         backgroundColor: Colors.black,
         foregroundColor: Colors.white,
       ),
       onPressed: (widget.result.advertisementData.connectable) ? widget.onTap : null,
+      child: isConnected ? const Text('OPEN') : const Text('CONNECT'),
     );
   }
 

--- a/packages/flutter_blue_plus/example/lib/widgets/service_tile.dart
+++ b/packages/flutter_blue_plus/example/lib/widgets/service_tile.dart
@@ -7,7 +7,7 @@ class ServiceTile extends StatelessWidget {
   final BluetoothService service;
   final List<CharacteristicTile> characteristicTiles;
 
-  const ServiceTile({Key? key, required this.service, required this.characteristicTiles}) : super(key: key);
+  const ServiceTile({super.key, required this.service, required this.characteristicTiles});
 
   Widget buildUuid(BuildContext context) {
     String uuid = '0x${service.uuid.str.toUpperCase()}';

--- a/packages/flutter_blue_plus/example/lib/widgets/system_device_tile.dart
+++ b/packages/flutter_blue_plus/example/lib/widgets/system_device_tile.dart
@@ -12,8 +12,8 @@ class SystemDeviceTile extends StatefulWidget {
     required this.device,
     required this.onOpen,
     required this.onConnect,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<SystemDeviceTile> createState() => _SystemDeviceTileState();
@@ -52,8 +52,8 @@ class _SystemDeviceTileState extends State<SystemDeviceTile> {
       title: Text(widget.device.platformName),
       subtitle: Text(widget.device.remoteId.str),
       trailing: ElevatedButton(
-        child: isConnected ? const Text('OPEN') : const Text('CONNECT'),
         onPressed: isConnected ? widget.onOpen : widget.onConnect,
+        child: isConnected ? const Text('OPEN') : const Text('CONNECT'),
       ),
     );
   }

--- a/packages/flutter_blue_plus/example/macos/Podfile.lock
+++ b/packages/flutter_blue_plus/example/macos/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
 
 SPEC CHECKSUMS:
-  flutter_blue_plus_darwin: 3ea4ec9133b377febcc8a70b28cd2d2dc9242bd9
+  flutter_blue_plus_darwin: 904ed52825285a15f60e9d90312337a09f11a785
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367

--- a/packages/flutter_blue_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/flutter_blue_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/flutter_blue_plus/example/pubspec.lock
+++ b/packages/flutter_blue_plus/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -67,7 +67,7 @@ packages:
       path: "../../flutter_blue_plus_android"
       relative: true
     source: path
-    version: "4.0.2"
+    version: "4.0.3"
   flutter_blue_plus_darwin:
     dependency: "direct overridden"
     description:
@@ -81,14 +81,14 @@ packages:
       path: "../../flutter_blue_plus_linux"
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_blue_plus_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flutter_blue_plus_platform_interface"
       relative: true
     source: path
-    version: "4.0.1"
+    version: "4.0.2"
   flutter_blue_plus_web:
     dependency: "direct overridden"
     description:
@@ -179,5 +179,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.7.0"

--- a/packages/flutter_blue_plus/lib/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/flutter_blue_plus.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library flutter_blue_plus;
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 final Guid cccdUuid = Guid("00002902-0000-1000-8000-00805f9b34fb");
 

--- a/packages/flutter_blue_plus/lib/src/bluetooth_descriptor.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_descriptor.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 class BluetoothDescriptor {
   final DeviceIdentifier remoteId;

--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -368,7 +368,7 @@ class BluetoothDevice {
   Stream<void> get onServicesReset {
     return FlutterBluePlusPlatform.instance.onServicesReset
         .where((p) => p.remoteId == remoteId)
-        .map((m) => null);
+        .map<void>((_) { /* no return, so this is a void callback */ });
   }
 
   /// Read the RSSI of connected remote device

--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 class BluetoothDevice {
   final DeviceIdentifier remoteId;

--- a/packages/flutter_blue_plus/lib/src/bluetooth_events.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_events.dart
@@ -1,4 +1,4 @@
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 class BluetoothEvents {
   Stream<OnConnectionStateChangedEvent> get onConnectionStateChanged {

--- a/packages/flutter_blue_plus/lib/src/bluetooth_service.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_service.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 class BluetoothService {
   final DeviceIdentifier remoteId;

--- a/packages/flutter_blue_plus/lib/src/bluetooth_utils.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_utils.dart
@@ -1,4 +1,4 @@
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 /// State of the bluetooth adapter.
 enum BluetoothAdapterState { unknown, unavailable, unauthorized, turningOn, on, turningOff, off }

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 class FlutterBluePlus {
   ///////////////////
@@ -144,11 +144,8 @@ class FlutterBluePlus {
     // get current state if needed
     if (_adapterStateNow == null) {
       var result = await _invokeMethod(() => FlutterBluePlusPlatform.instance.getAdapterState(BmBluetoothAdapterStateRequest()));
-      var value = result.adapterState;
       // update _adapterStateNow if it is still null after the await
-      if (_adapterStateNow == null) {
-        _adapterStateNow = value;
-      }
+      _adapterStateNow ??= result.adapterState;
     }
 
     yield* FlutterBluePlusPlatform.instance.onAdapterStateChanged

--- a/packages/flutter_blue_plus/lib/src/utils.dart
+++ b/packages/flutter_blue_plus/lib/src/utils.dart
@@ -1,4 +1,4 @@
-part of flutter_blue_plus;
+part of '../flutter_blue_plus.dart';
 
 extension AddOrUpdate<T> on List<T> {
   /// add an item to a list, or update item if it already exists
@@ -14,7 +14,7 @@ extension AddOrUpdate<T> on List<T> {
 
 extension FutureTimeout<T> on Future<T> {
   Future<T> fbpTimeout(int seconds, String function) {
-    return this.timeout(Duration(seconds: seconds), onTimeout: () {
+    return timeout(Duration(seconds: seconds), onTimeout: () {
       throw FlutterBluePlusException(
           ErrorPlatform.fbp, function, FbpErrorCode.timeout.index, "Timed out after ${seconds}s");
     });
@@ -36,7 +36,7 @@ extension FutureTimeout<T> on Future<T> {
 
     // When the original future completes
     // complete our completer and cancel the subscription.
-    this.then((value) {
+    then((value) {
       if (!completer.isCompleted) {
         subscription.cancel();
         completer.complete(value);
@@ -67,7 +67,7 @@ extension FutureTimeout<T> on Future<T> {
 
     // When the original future completes
     // complete our completer and cancel the subscription.
-    this.then((value) {
+    then((value) {
       if (!completer.isCompleted) {
         subscription.cancel();
         completer.complete(value);
@@ -92,7 +92,7 @@ class _StreamControllerReEmit<T> {
 
   final StreamController<T> _controller = StreamController<T>.broadcast();
 
-  _StreamControllerReEmit({required T initialValue}) : this.latestValue = initialValue;
+  _StreamControllerReEmit({required T initialValue}) : latestValue = initialValue;
 
   Stream<T> get stream {
     if (latestValue != null) {
@@ -382,8 +382,8 @@ extension FirstWhereOrNullExtension<T> on Iterable<T> {
 extension RemoveWhere<T> on List<T> {
   /// returns true if some items where removed
   bool _removeWhere(bool Function(T) test) {
-    int initialLength = this.length;
-    this.removeWhere(test);
-    return this.length != initialLength;
+    int initialLength = length;
+    removeWhere(test);
+    return length != initialLength;
   }
 }

--- a/packages/flutter_blue_plus_android/analysis_options.yaml
+++ b/packages/flutter_blue_plus_android/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at

--- a/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -1609,13 +1609,16 @@ public class FlutterBluePlusPlugin implements
         if (Build.VERSION.SDK_INT >= 31) {
             // Android 12 (October 2021) - location services are not required for BLE scanning
             return true;
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        }
+
+        Context context = pluginBinding.getApplicationContext();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             // This is a new method provided in API 28 / Android 9 August 2018
-            LocationManager lm = (LocationManager) activityBinding.getActivity().getSystemService(Context.LOCATION_SERVICE);
+            LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
             return lm != null && lm.isLocationEnabled();
         } else {
             // This was deprecated in API 28
-            int mode = Settings.Secure.getInt(activityBinding.getActivity().getContentResolver(),
+            int mode = Settings.Secure.getInt(context.getContentResolver(),
                 Settings.Secure.LOCATION_MODE, Settings.Secure.LOCATION_MODE_OFF);
             return mode != Settings.Secure.LOCATION_MODE_OFF;
         }

--- a/packages/flutter_blue_plus_darwin/analysis_options.yaml
+++ b/packages/flutter_blue_plus_darwin/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at

--- a/packages/flutter_blue_plus_linux/analysis_options.yaml
+++ b/packages/flutter_blue_plus_linux/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at

--- a/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
+++ b/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
@@ -22,7 +22,7 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
   Stream<BmBluetoothAdapterState> get onAdapterStateChanged {
     return _client.adaptersChanged.where(
       (adapters) {
-        return adapters.length > 0;
+        return adapters.isNotEmpty;
       },
     ).switchMap(
       (adapters) {
@@ -522,7 +522,7 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
   ) async {
     await _initFlutterBluePlus();
 
-    return _client.adapters.length > 0;
+    return _client.adapters.isNotEmpty;
   }
 
   @override

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -113,7 +113,7 @@ class BmScanSettings {
     data['android_scan_mode'] = androidScanMode;
     data['android_uses_fine_location'] = androidUsesFineLocation;
     data['android_check_location_services'] = androidCheckLocationServices;
-    data['web_optional_services'] = webOptionalServices.map((s) => s.str).toList();;
+    data['web_optional_services'] = webOptionalServices.map((s) => s.str).toList();
     return data;
   }
 }
@@ -177,7 +177,7 @@ class BmScanAdvertisement {
       manufacturerData: manufacturerData,
       serviceData: serviceData,
       serviceUuids: serviceUuids,
-      rssi: json['rssi'] != null ? json['rssi'] : 0,
+      rssi: json['rssi'] ?? 0,
     );
   }
 }

--- a/packages/flutter_blue_plus_platform_interface/lib/src/guid.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/guid.dart
@@ -14,7 +14,7 @@ class Guid {
   Guid(String input) : bytes = _toBytes(input);
 
   static Guid? parse(String? input) {
-    if (input == null || input.length == 0) {
+    if (input == null || input.isEmpty) {
       return null;
     } else {
       return Guid(input);

--- a/packages/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
+++ b/packages/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
@@ -489,7 +489,7 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
 
       final RequestDeviceOptions options;
 
-      if (filters.length > 0) {
+      if (filters.isNotEmpty) {
         options = RequestDeviceOptions(
           filters: filters.toJS,
           optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,


### PR DESCRIPTION
This PR fixes most of the linter issues.

Things that hasn't fixed:

* info: Don't invoke 'print' in production code
  _seem to be part of a custom logging and we need to either disable lint or add ignore everywhere_

* [info: Don't return 'null' from a function with a return type of 'void'. (avoid_returning_null_for_void at [flutter_blue_plus] lib/src/bluetooth_device.dart:371)](https://github.com/chipweinberger/flutter_blue_plus/blob/38a09f22ef1ae8789a398a227f0fce7a2369a547/packages/flutter_blue_plus/lib/src/bluetooth_device.dart#L368-L372)
  _not really sure how to fix this_

* [info: Don't return 'null' from a method with a return type of 'void'. (avoid_returning_null_for_void at [flutter_blue_plus] lib/src/flutter_blue_plus.dart:634)](https://github.com/chipweinberger/flutter_blue_plus/blob/38a09f22ef1ae8789a398a227f0fce7a2369a547/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart#L633-L634)
  _not sure how to fix this, but maybe it is about time to remove this one_

* [info: The null check operator shouldn't be used on a variable whose type is a potentially nullable type parameter. (null_check_on_nullable_type_parameter at [flutter_blue_plus_example] lib/utils/utils.dart:14)](https://github.com/chipweinberger/flutter_blue_plus/blob/5934d505f4625e9d17c7cd2171f684d07876516f/packages/flutter_blue_plus/example/lib/utils/utils.dart#L14)
  _the proposed fix is to replace `_latestValue!` with `_latestValue as T` but I'm not sure how to test this code in the example app_
