### PR TITLE
[iOS] Fix crash on incorrect PIN

### DIFF
--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -1437,7 +1437,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         @"service_uuid":                [characteristic.service.UUID uuidStr],
         @"characteristic_uuid":         [characteristic.UUID uuidStr],
         @"primary_service_uuid":        primaryService ? [primaryService.UUID uuidStr] : [NSNull null],
-        @"value":                       characteristic.value,
+        @"value":                       characteristic.value ? characteristic.value : [NSNull null],
         @"success":                     error == nil ? @(1) : @(0),
         @"error_string":                error ? [error localizedDescription] : @"success",
         @"error_code":                  error ? @(error.code) : @(0),


### PR DESCRIPTION
On iOS, reading an encrypted characteristic to trigger the PIN prompt, then entering an incorrect PIN causes a crash.

```
[FBP-iOS] didUpdateValueForCharacteristic:
[FBP-iOS]   chr: 318848ff-f881-44a8-9f65-25be4801594f
[FBP-iOS]   error: Encryption is insufficient.
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[4]'
```

Resolved by providing a null object for `value` in the result dictionary as is done for `primary_service_uuid`.