### PR TITLE
[Android] Fix Services Change listener - onServicesReset was not firing due to incorrect service and characteristic checks

### DIFF
--- a/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -2329,11 +2329,13 @@ public class FlutterBluePlusPlugin implements
         // called for both notifications & reads
         public void onCharacteristicReceived(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, int status)
         {
-            // GATT Service?
-            if (uuidStr(characteristic.getService().getUuid()) == "1801") {
+            // https://www.bluetooth.com/wp-content/uploads/Files/Specification/Assigned_Numbers.html
 
-                // services changed
-                if (uuidStr(characteristic.getUuid()) == "2A05") {
+            // Generic Attribute service 0x1801
+            if (uuidStr(characteristic.getService().getUuid()).equals("1801")) {
+
+                // Service Changed 0x2A05
+                if (uuidStr(characteristic.getUuid()).toUpperCase().equals("2A05")) {
                     HashMap<String, Object> response = bmBluetoothDevice(gatt.getDevice());
                     invokeMethodUIThread("OnServicesReset", response);
                 }

--- a/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -2330,7 +2330,7 @@ public class FlutterBluePlusPlugin implements
         public void onCharacteristicReceived(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, int status)
         {
             // GATT Service?
-            if (uuidStr(characteristic.getService().getUuid()) == "1800") {
+            if (uuidStr(characteristic.getService().getUuid()) == "1801") {
 
                 // services changed
                 if (uuidStr(characteristic.getUuid()) == "2A05") {


### PR DESCRIPTION
This PR fixes #1211 and it corrects the logic that detects the **Services Changed** characteristic (`0x2A05`) in `flutter_blue_plus_android`.

#### What was wrong

* The code was checking for service `0x1800` (GAP), but `0x2A05` belongs to the **GATT service** `0x1801`.
* It used `==` instead of `.equals()` for string comparison.
* It also didn't normalize the case when comparing `0x2A05`.

As a result, `onServicesReset` was never triggered, even when a valid notification was received.

#### Validation

* https://www.bluetooth.com/wp-content/uploads/Files/Specification/Assigned_Numbers.html
* Tested manually by modifying the plugin and using a BLE device that triggers `0x2A05`.
* Also confirmed via Dart subscription to the same characteristic, which did work.