### PR TITLE
iOS add CBConnectPeripheralOptionRequiresANCS and CBConnectPeripheralOptionEnableTransportBridgingKey options when connect device.

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -97,10 +97,14 @@ class BluetoothDevice {
   ///      - auto connect is turned off by calling `disconnect`
   ///      - auto connect results in a slower connection process compared to a direct connection
   ///        because it relies on the internal scheduling of background scans.
+  ///   [enableTransportBridging] iOS only. This option tells the system to connect non-GATT profiles on classic Bluetooth devices, if there is a low energy GATT connection to the same device.
+  ///   [requiresANCS] iOS only. An option to require Apple Notification Center Service (ANCS) when connecting a device..
   Future<void> connect({
     Duration timeout = const Duration(seconds: 35),
     int? mtu = 512,
     bool autoConnect = false,
+    bool enableTransportBridging = false,
+    bool requiresANCS = false,
   }) async {
     // If you hit this assert, you must set `mtu:null`, i.e `device.connect(mtu:null, autoConnect:true)`
     // and you'll have to call `requestMtu` yourself. `autoConnect` is not compatibile with `mtu`.
@@ -124,6 +128,8 @@ class BluetoothDevice {
       var request = BmConnectRequest(
         remoteId: remoteId,
         autoConnect: autoConnect,
+        enableTransportBridging: enableTransportBridging,
+        requiresANCS: requiresANCS,
       );
 
       var responseStream = FlutterBluePlusPlatform

--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -322,9 +322,11 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         else if ([@"connect" isEqualToString:call.method])
         {
             // See BmConnectRequest
-            NSDictionary* args = (NSDictionary*)call.arguments;
-            NSString  *remoteId       = args[@"remote_id"];
-            NSNumber  *autoConnect    = args[@"auto_connect"];
+            NSDictionary *args = (NSDictionary *)call.arguments;
+            NSString *remoteId                  = args[@"remote_id"];
+            NSNumber *autoConnect               = args[@"auto_connect"];
+            NSNumber *enableTransportBridging   = args[@"enableTransportBridging"];
+            NSNumber *requiresANCS              = args[@"requiresANCS"];
 
             // check adapter state
             if ([self isAdapterOn] == false) {
@@ -385,7 +387,10 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                 // note: use CBConnectPeripheralOptionEnableAutoReconnect constant
                 // when all developers can be excpected to be on iOS 17+
                 [options setObject:autoConnect forKey:@"kCBConnectOptionEnableAutoReconnect"];
-            } 
+            }
+
+            [options setObject:enableTransportBridging forKey:CBConnectPeripheralOptionEnableTransportBridgingKey];
+            [options setObject:requiresANCS forKey:CBConnectPeripheralOptionRequiresANCS];
 
             [self.centralManager connectPeripheral:peripheral options:options];
 


### PR DESCRIPTION
iOS add CBConnectPeripheralOptionRequiresANCS and CBConnectPeripheralOptionEnableTransportBridgingKey options when connect device.
