### PR TITLE
move logging from FlutterBluePlus class to FlutterBluePlusPlatform

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -153,7 +153,7 @@ class BluetoothDevice {
             .catchError((e) async {
           if (e is FlutterBluePlusException &&
               e.code == FbpErrorCode.timeout.index) {
-            FlutterBluePlus.log("[FBP] connection timeout");
+            FlutterBluePlusPlatform.log("[FBP] connection timeout");
             await FlutterBluePlus._invokeMethod(() =>
                 FlutterBluePlusPlatform.instance.disconnect(BmDisconnectRequest(
                     remoteId: remoteId))); // cancel connection attempt
@@ -720,7 +720,7 @@ class BluetoothDevice {
             .difference(FlutterBluePlus._connectTimestamp[remoteId]!);
         if (elapsed.compareTo(minGap) < 0) {
           Duration timeLeft = minGap - elapsed;
-          FlutterBluePlus.log(
+          FlutterBluePlusPlatform.log(
               "[FBP] disconnect: enforcing ${minGap.inMilliseconds}ms disconnect gap, delaying "
               "${timeLeft.inMilliseconds}ms");
           await Future<void>.delayed(timeLeft);

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -635,7 +635,7 @@ class FlutterBluePlus {
   static Future<List<BluetoothDevice>> get connectedSystemDevices => systemDevices([Guid("1800")]);
 
   @Deprecated('No longer needed, remove this from your code')
-  static void get instance {}
+  static void get instance => null;
 
   @Deprecated('Use isSupported instead')
   static Future<bool> get isAvailable async => await isSupported;

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -32,9 +32,6 @@ class FlutterBluePlus {
   /// stream used for the scanResults public api
   static final _scanResults = _StreamControllerReEmit<List<ScanResult>>(initialValue: []);
 
-  /// stream used for the scanResults public api
-  static final _logsController = StreamController<String>.broadcast();
-
   /// buffers the scan results
   static _BufferStream<BmScanResponse>? _scanBuffer;
 
@@ -99,7 +96,7 @@ class FlutterBluePlus {
   static final BluetoothEvents events = BluetoothEvents();
 
   /// Get access to FBP logs
-  static Stream<String> get logs => _logsController.stream;
+  static Stream<String> get logs => FlutterBluePlusPlatform.logs;
 
   /// Set configurable options
   ///   - [showPowerAlert] Whether to show the power alert (iOS & MacOS only). i.e. CBCentralManagerOptionShowPowerAlertKey
@@ -367,7 +364,7 @@ class FlutterBluePlus {
       if (isScanningNow) {
         await _stopScan();
       } else if (_logLevel.index >= LogLevel.info.index) {
-        log("[FBP] stopScan: already stopped");
+        FlutterBluePlusPlatform.log("[FBP] stopScan: already stopped");
       }
     } finally {
       mtx.give();
@@ -439,7 +436,7 @@ class FlutterBluePlus {
           for (DeviceIdentifier d in _autoConnect) {
             BluetoothDevice(remoteId: d).connect(autoConnect: true, mtu: null).onError((e, s) {
               if (logLevel != LogLevel.none) {
-                log("[FBP] [AutoConnect] connection failed: $e");
+                FlutterBluePlusPlatform.log("[FBP] [AutoConnect] connection failed: $e");
               }
             });
           }
@@ -478,7 +475,7 @@ class FlutterBluePlus {
                 var d = BluetoothDevice(remoteId: r.remoteId);
                 d.connect(autoConnect: true, mtu: null).onError((e, s) {
                   if (logLevel != LogLevel.none) {
-                    log("[FBP] [AutoConnect] connection failed: $e");
+                     FlutterBluePlusPlatform.log("[FBP] [AutoConnect] connection failed: $e");
                   }
                 });
               }
@@ -623,10 +620,6 @@ class FlutterBluePlus {
     }
   }
 
-  static void log(String s) {
-    _logsController.add(s);
-    print(s);
-  }
 
   /// Checks if Bluetooth functionality is turned on
   @Deprecated('Use adapterState.first == BluetoothAdapterState.on instead')
@@ -642,7 +635,7 @@ class FlutterBluePlus {
   static Future<List<BluetoothDevice>> get connectedSystemDevices => systemDevices([Guid("1800")]);
 
   @Deprecated('No longer needed, remove this from your code')
-  static void get instance => null;
+  static void get instance {}
 
   @Deprecated('Use isSupported instead')
   static Future<bool> get isAvailable async => await isSupported;

--- a/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart
+++ b/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart
@@ -407,7 +407,7 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
       var args = arguments.toString();
       func = _logColor ? '\x1B[1;30m$func\x1B[0m' : func;
       args = _logColor ? '\x1B[1;35m$args\x1B[0m' : args;
-      print('[FBP] $func args: $args');
+      FlutterBluePlusPlatform.log('[FBP] $func args: $args');
     }
 
     // invoke
@@ -419,7 +419,7 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
       var result = out.toString();
       func = _logColor ? '\x1B[1;30m$func\x1B[0m' : func;
       result = _logColor ? '\x1B[1;33m$result\x1B[0m' : result;
-      print('[FBP] $func result: $result');
+      FlutterBluePlusPlatform.log('[FBP] $func result: $result');
     }
 
     return out;
@@ -456,7 +456,7 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
       };
       func = _logColor ? '\x1B[1;30m$func\x1B[0m' : func;
       result = _logColor ? '\x1B[1;33m$result\x1B[0m' : result;
-      print('[FBP] $func result: $result');
+      FlutterBluePlusPlatform.log('[FBP] $func result: $result');
     }
 
     // handle method call

--- a/packages/flutter_blue_plus_darwin/lib/flutter_blue_plus_darwin.dart
+++ b/packages/flutter_blue_plus_darwin/lib/flutter_blue_plus_darwin.dart
@@ -278,7 +278,7 @@ final class FlutterBluePlusDarwin extends FlutterBluePlusPlatform {
       var args = arguments.toString();
       func = _logColor ? '\x1B[1;30m$func\x1B[0m' : func;
       args = _logColor ? '\x1B[1;35m$args\x1B[0m' : args;
-      print('[FBP] $func args: $args');
+      FlutterBluePlusPlatform.log('[FBP] $func args: $args');
     }
 
     // invoke
@@ -290,7 +290,7 @@ final class FlutterBluePlusDarwin extends FlutterBluePlusPlatform {
       var result = out.toString();
       func = _logColor ? '\x1B[1;30m$func\x1B[0m' : func;
       result = _logColor ? '\x1B[1;33m$result\x1B[0m' : result;
-      print('[FBP] $func result: $result');
+      FlutterBluePlusPlatform.log('[FBP] $func result: $result');
     }
 
     return out;
@@ -327,7 +327,7 @@ final class FlutterBluePlusDarwin extends FlutterBluePlusPlatform {
       };
       func = _logColor ? '\x1B[1;30m$func\x1B[0m' : func;
       result = _logColor ? '\x1B[1;33m$result\x1B[0m' : result;
-      print('[FBP] $func result: $result');
+      FlutterBluePlusPlatform.log('[FBP] $func result: $result');
     }
 
     // handle method call

--- a/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
+++ b/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
@@ -1046,7 +1046,7 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
     _client.devicesChanged.switchMap(
       (devices) {
         if (_logLevel == LogLevel.verbose) {
-          print(
+          FlutterBluePlusPlatform.log(
             '[FBP-Linux] devices changed ${devices.map((device) => device.remoteId).toList()}',
           );
         }
@@ -1057,7 +1057,7 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
               return device.propertiesChanged.switchMap(
                 (properties) {
                   if (_logLevel == LogLevel.verbose) {
-                    print(
+                    FlutterBluePlusPlatform.log(
                       '[FBP-Linux] device ${device.remoteId} properties changed $properties',
                     );
                   }
@@ -1070,7 +1070,7 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
                         characteristic.propertiesChanged.map(
                           (properties) {
                             if (_logLevel == LogLevel.verbose) {
-                              print(
+                              FlutterBluePlusPlatform.log(
                                 '[FBP-Linux] device ${device.remoteId} service ${service.uuid} characteristic ${characteristic.uuid} properties changed $properties',
                               );
                             }

--- a/packages/flutter_blue_plus_platform_interface/lib/flutter_blue_plus_platform_interface.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/flutter_blue_plus_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'src/bluetooth_msgs.dart';
 
 export 'src/bluetooth_msgs.dart';
@@ -87,6 +89,14 @@ abstract base class FlutterBluePlusPlatform {
 
   Stream<BmTurnOnResponse> get onTurnOnResponse {
     return Stream.empty();
+  }
+
+  static final _logsController = StreamController<String>.broadcast();
+  static Stream<String> get logs => _logsController.stream;
+  
+  static void log(String s) {
+    _logsController.add(s);
+    print(s);
   }
 
   Future<bool> clearGattCache(


### PR DESCRIPTION
I propose this changes in order to collect all logs from platform, moving logging functionality from  `FlutterBluePlus` to `FlutterBluePlusPlatform`.

In this way, listeners of `FlutterBluePlus.logs` stream really catch all logs yield by all platform packages (not only from package `FlutterBluePlus`).

I test only `android` platform.

