### PR TITLE
Add CDM Support [ # 1248 ]

### DIFF
--- a/packages/flutter_blue_plus/example/lib/screens/scan_screen.dart
+++ b/packages/flutter_blue_plus/example/lib/screens/scan_screen.dart
@@ -7,7 +7,6 @@ import 'device_screen.dart';
 import '../utils/snackbar.dart';
 import '../widgets/system_device_tile.dart';
 import '../widgets/scan_result_tile.dart';
-import '../utils/extra.dart';
 
 class ScanScreen extends StatefulWidget {
   const ScanScreen({super.key});
@@ -96,7 +95,12 @@ class _ScanScreenState extends State<ScanScreen> {
   }
 
   void onConnectPressed(BluetoothDevice device) {
-    device.connectAndUpdateStream().catchError((e) {
+    // Use CDM-aware connection that automatically detects and handles CDM devices
+    BluetoothCdmHelper.connectWithCdmDetection(device).then((wasCdmDevice) {
+      if (wasCdmDevice) {
+        Snackbar.show(ABC.c, "Connected to CDM device: ${device.platformName}", success: true);
+      }
+    }).catchError((e) {
       Snackbar.show(ABC.c, prettyException("Connect Error:", e), success: false);
     });
     MaterialPageRoute route = MaterialPageRoute(

--- a/packages/flutter_blue_plus/example/lib/widgets/scan_result_tile.dart
+++ b/packages/flutter_blue_plus/example/lib/widgets/scan_result_tile.dart
@@ -15,6 +15,7 @@ class ScanResultTile extends StatefulWidget {
 
 class _ScanResultTileState extends State<ScanResultTile> {
   BluetoothConnectionState _connectionState = BluetoothConnectionState.disconnected;
+  bool _isCdmDevice = false;
 
   late StreamSubscription<BluetoothConnectionState> _connectionStateSubscription;
 
@@ -28,6 +29,22 @@ class _ScanResultTileState extends State<ScanResultTile> {
         setState(() {});
       }
     });
+
+    // Check if device is CDM-associated
+    _checkCdmStatus();
+  }
+
+  void _checkCdmStatus() async {
+    try {
+      bool isCdm = await BluetoothCdmHelper.isDeviceAssociated(widget.result.device.remoteId.str);
+      if (mounted) {
+        setState(() {
+          _isCdmDevice = isCdm;
+        });
+      }
+    } catch (e) {
+      // CDM check failed, probably not supported
+    }
   }
 
   @override
@@ -62,9 +79,31 @@ class _ScanResultTileState extends State<ScanResultTile> {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(
-            widget.result.device.platformName,
-            overflow: TextOverflow.ellipsis,
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.result.device.platformName,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (_isCdmDevice)
+                Container(
+                  padding: EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.green,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    'CDM',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+            ],
           ),
           Text(
             widget.result.device.remoteId.str,
@@ -73,7 +112,29 @@ class _ScanResultTileState extends State<ScanResultTile> {
         ],
       );
     } else {
-      return Text(widget.result.device.remoteId.str);
+      return Row(
+        children: [
+          Expanded(
+            child: Text(widget.result.device.remoteId.str),
+          ),
+          if (_isCdmDevice)
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.green,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                'CDM',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+        ],
+      );
     }
   }
 

--- a/packages/flutter_blue_plus/example/pubspec.lock
+++ b/packages/flutter_blue_plus/example/pubspec.lock
@@ -60,42 +60,42 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.35.5"
+    version: "1.36.0"
   flutter_blue_plus_android:
     dependency: "direct overridden"
     description:
       path: "../../flutter_blue_plus_android"
       relative: true
     source: path
-    version: "4.0.5"
+    version: "4.1.0"
   flutter_blue_plus_darwin:
     dependency: "direct overridden"
     description:
       path: "../../flutter_blue_plus_darwin"
       relative: true
     source: path
-    version: "4.0.1"
+    version: "4.1.0"
   flutter_blue_plus_linux:
     dependency: "direct overridden"
     description:
       path: "../../flutter_blue_plus_linux"
       relative: true
     source: path
-    version: "3.0.2"
+    version: "3.1.0"
   flutter_blue_plus_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flutter_blue_plus_platform_interface"
       relative: true
     source: path
-    version: "4.0.2"
+    version: "4.1.0"
   flutter_blue_plus_web:
     dependency: "direct overridden"
     description:
       path: "../../flutter_blue_plus_web"
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -158,10 +158,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   web:
     dependency: transitive
     description:
@@ -179,5 +179,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.7.0"

--- a/packages/flutter_blue_plus/lib/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/flutter_blue_plus.dart
@@ -8,11 +8,13 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_blue_plus_platform_interface/flutter_blue_plus_platform_interface.dart';
 
 export 'package:flutter_blue_plus_platform_interface/flutter_blue_plus_platform_interface.dart' show DeviceIdentifier, Guid, LogLevel, PhySupport;
 
 part 'src/bluetooth_characteristic.dart';
+part 'src/bluetooth_cdm_helper.dart';
 part 'src/bluetooth_descriptor.dart';
 part 'src/bluetooth_device.dart';
 part 'src/bluetooth_events.dart';

--- a/packages/flutter_blue_plus/lib/src/bluetooth_cdm_helper.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_cdm_helper.dart
@@ -1,0 +1,149 @@
+// Copyright 2017-2023, Charles Weinberger & Paul DeMarco.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of '../flutter_blue_plus.dart';
+
+/// Android Companion Device Manager (CDM) helper utilities
+/// 
+/// CDM is available on Android 8.0+ and provides a streamlined pairing
+/// experience for companion devices like wearables, IoT devices, and AR glasses.
+/// CDM devices often reject traditional Bluetooth bonding and should use
+/// CDM-specific connection parameters.
+class BluetoothCdmHelper {
+  
+  /// Check if Companion Device Manager is supported on this platform
+  /// Returns true on Android 8.0+ devices, false otherwise
+  static Future<bool> get isSupported async {
+    if (kIsWeb || !Platform.isAndroid) {
+      return false;
+    }
+    // CDM was introduced in Android API 26 (Android 8.0)
+    return true;
+  }
+
+  /// Check if a specific device is associated via Companion Device Manager
+  /// 
+  /// [deviceId] The device identifier (MAC address on Android)
+  /// Returns true if the device is CDM-associated, false otherwise
+  static Future<bool> isDeviceAssociated(String deviceId) async {
+    if (!await isSupported) {
+      return false;
+    }
+
+    try {
+      final MethodChannel methodChannel = MethodChannel('flutter_blue_plus/methods');
+      return await methodChannel.invokeMethod('isCdmDeviceAssociated', deviceId) ?? false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Get all devices currently associated via Companion Device Manager
+  /// 
+  /// Returns a list of device identifiers that are CDM-associated
+  static Future<List<String>> getAssociatedDevices() async {
+    if (!await isSupported) {
+      return [];
+    }
+
+    try {
+      final MethodChannel methodChannel = MethodChannel('flutter_blue_plus/methods');
+      final List<dynamic> result = await methodChannel.invokeMethod('getCdmAssociatedDevices') ?? [];
+      return result.cast<String>();
+    } catch (e) {
+      return [];
+    }
+  }
+
+  /// Start the Android CDM pairing process with system dialog
+  /// 
+  /// This will show the system Companion Device Manager pairing dialog
+  /// allowing the user to select and associate a companion device.
+  /// 
+  /// Returns the device identifier of the paired device, or null if cancelled
+  static Future<String?> startCdmPairing() async {
+    if (!await isSupported) {
+      throw PlatformException(
+        code: 'CDM_NOT_SUPPORTED',
+        message: 'Companion Device Manager not supported on this device',
+      );
+    }
+
+    try {
+      final MethodChannel methodChannel = MethodChannel('flutter_blue_plus/methods');
+      final String? deviceId = await methodChannel.invokeMethod('startCdmPairing');
+      return deviceId;
+    } catch (e) {
+      if (e is PlatformException) {
+        rethrow;
+      }
+      throw PlatformException(
+        code: 'CDM_ERROR',
+        message: 'Failed to start CDM pairing: $e',
+      );
+    }
+  }
+
+  /// Remove CDM association for a specific device
+  /// 
+  /// [deviceId] The device identifier to remove association for
+  /// Returns true if the association was successfully removed
+  /// 
+  /// Note: This requires Android 13+ (API 33). On older versions, 
+  /// associations can only be removed by uninstalling the app.
+  static Future<bool> removeAssociation(String deviceId) async {
+    if (!await isSupported) {
+      return false;
+    }
+
+    try {
+      final MethodChannel methodChannel = MethodChannel('flutter_blue_plus/methods');
+      final bool removed = await methodChannel.invokeMethod('removeCdmAssociation', deviceId) ?? false;
+      return removed;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Helper method to connect to a device with appropriate CDM settings
+  /// 
+  /// This method automatically detects if a device is CDM-associated and
+  /// applies the correct connection parameters to prevent bonding conflicts.
+  /// 
+  /// [device] The Bluetooth device to connect to
+  /// [timeout] Connection timeout duration
+  /// [mtu] Android only. Request a larger mtu right after connection
+  /// [autoConnect] Enable auto-reconnection
+  /// 
+  /// Returns true if connection parameters were applied, false otherwise
+  static Future<bool> connectWithCdmDetection(
+    BluetoothDevice device, {
+    Duration timeout = const Duration(seconds: 35),
+    int? mtu = 512,
+    bool autoConnect = false,
+  }) async {
+    bool isCdmDevice = await isDeviceAssociated(device.remoteId.str);
+    
+    await device.connect(
+      timeout: timeout,
+      mtu: mtu,
+      autoConnect: autoConnect,
+      allowAutoBonding: !isCdmDevice,
+      isCdmDevice: isCdmDevice,
+    );
+
+    return isCdmDevice;
+  }
+
+  /// Create a BluetoothDevice from a device ID with CDM-aware connection helper
+  /// 
+  /// This is a convenience method that combines device creation and CDM detection.
+  /// 
+  /// [deviceId] The device identifier (MAC address on Android, UUID on iOS)
+  /// 
+  /// Returns a BluetoothDevice configured for CDM-aware connections
+  static BluetoothDevice deviceFromId(String deviceId) {
+    return BluetoothDevice.fromId(deviceId);
+  }
+}

--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -97,10 +97,16 @@ class BluetoothDevice {
   ///      - auto connect is turned off by calling `disconnect`
   ///      - auto connect results in a slower connection process compared to a direct connection
   ///        because it relies on the internal scheduling of background scans.
+  ///   [allowAutoBonding] Android only. If false, disables automatic bonding for this device.
+  ///      - Useful for CDM devices that reject traditional Bluetooth bonding
+  ///   [isCdmDevice] Android only. Indicates this device was associated via Companion Device Manager
+  ///      - When true, automatically disables auto-bonding to prevent connection failures
   Future<void> connect({
     Duration timeout = const Duration(seconds: 35),
     int? mtu = 512,
     bool autoConnect = false,
+    bool allowAutoBonding = true,
+    bool isCdmDevice = false,
   }) async {
     // If you hit this assert, you must set `mtu:null`, i.e `device.connect(mtu:null, autoConnect:true)`
     // and you'll have to call `requestMtu` yourself. `autoConnect` is not compatibile with `mtu`.
@@ -124,6 +130,8 @@ class BluetoothDevice {
       var request = BmConnectRequest(
         remoteId: remoteId,
         autoConnect: autoConnect,
+        allowAutoBonding: allowAutoBonding,
+        isCdmDevice: isCdmDevice,
       );
 
       var responseStream = FlutterBluePlusPlatform

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -822,7 +822,8 @@ enum FbpErrorCode {
   characteristicNotFound,
   adapterIsOff,
   connectionCanceled,
-  userRejected
+  userRejected,
+  cdmAuthenticationRequired
 }
 
 class FlutterBluePlusException implements Exception {

--- a/packages/flutter_blue_plus/pubspec.yaml
+++ b/packages/flutter_blue_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus
 description: Flutter plugin for connecting and communicating with Bluetooth Low Energy devices.
-version: 1.35.5
+version: 1.36.0
 homepage: https://github.com/chipweinberger/flutter_blue_plus
 
 environment:
@@ -10,11 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_blue_plus_android: ^4.0.0
-  flutter_blue_plus_darwin: ^4.0.0
-  flutter_blue_plus_linux: ^3.0.0
-  flutter_blue_plus_platform_interface: ^4.0.2
-  flutter_blue_plus_web: ^3.0.0
+  flutter_blue_plus_android: ^4.1.0
+  flutter_blue_plus_darwin: ^4.1.0
+  flutter_blue_plus_linux: ^3.1.0
+  flutter_blue_plus_platform_interface: ^4.1.0
+  flutter_blue_plus_web: ^3.1.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/CdmBluetoothManager.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/CdmBluetoothManager.java
@@ -1,0 +1,354 @@
+// Copyright 2017-2023, Charles Weinberger & Paul DeMarco.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.lib.flutter_blue_plus;
+
+import android.app.Activity;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothProfile;
+import android.companion.AssociationRequest;
+import android.companion.BluetoothDeviceFilter;
+import android.companion.CompanionDeviceManager;
+import android.content.Context;
+import android.content.IntentSender;
+import android.os.Build;
+import android.util.Log;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import io.flutter.plugin.common.MethodChannel;
+
+/**
+ * Android Companion Device Manager (CDM) integration for Flutter Blue Plus
+ * 
+ * This class manages CDM device associations, pairing workflows, and 
+ * CDM-specific GATT operations that avoid traditional Bluetooth bonding.
+ * 
+ * CDM was introduced in Android 8.0 (API 26) to provide streamlined pairing
+ * for companion devices like wearables, IoT devices, and AR glasses.
+ */
+public class CdmBluetoothManager {
+    private static final String TAG = "[FBP-CDM]";
+    
+    // CDM request codes for activity results
+    private static final int REQUEST_CODE_CDM_PAIRING = 1001;
+    
+    private final Context context;
+    private final Activity activity;
+    private final CompanionDeviceManager companionDeviceManager;
+    private final BluetoothAdapter bluetoothAdapter;
+    
+    // Track CDM devices to prevent auto-bonding
+    private final Set<String> cdmDevices = ConcurrentHashMap.newKeySet();
+    
+    // Pending CDM pairing operations
+    private MethodChannel.Result pendingPairingResult;
+    
+    public CdmBluetoothManager(Context context, Activity activity, BluetoothAdapter bluetoothAdapter) {
+        this.context = context;
+        this.activity = activity;
+        this.bluetoothAdapter = bluetoothAdapter;
+        
+        if (Build.VERSION.SDK_INT >= 26) {
+            this.companionDeviceManager = (CompanionDeviceManager) 
+                context.getSystemService(Context.COMPANION_DEVICE_SERVICE);
+        } else {
+            this.companionDeviceManager = null;
+        }
+    }
+    
+    /**
+     * Check if CDM is supported on this device
+     */
+    public boolean isCdmSupported() {
+        return Build.VERSION.SDK_INT >= 26 && companionDeviceManager != null;
+    }
+    
+    /**
+     * Check if a device is associated via CDM
+     */
+    public boolean isDeviceAssociated(String deviceAddress) {
+        if (!isCdmSupported()) {
+            return false;
+        }
+        
+        try {
+            List<String> associations = companionDeviceManager.getAssociations();
+            return associations.contains(deviceAddress);
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to check CDM associations: " + e.getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * Get all CDM-associated devices
+     */
+    public List<String> getAssociatedDevices() {
+        if (!isCdmSupported()) {
+            return java.util.Collections.emptyList();
+        }
+        
+        try {
+            return companionDeviceManager.getAssociations();
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to get CDM associations: " + e.getMessage());
+            return java.util.Collections.emptyList();
+        }
+    }
+    
+    /**
+     * Start CDM pairing process with system dialog
+     */
+    public void startCdmPairing(MethodChannel.Result result) {
+        if (!isCdmSupported()) {
+            result.error("CDM_NOT_SUPPORTED", "Companion Device Manager not supported on this device", null);
+            return;
+        }
+        
+        if (activity == null) {
+            result.error("NO_ACTIVITY", "Activity required for CDM pairing", null);
+            return;
+        }
+        
+        try {
+            // Create a generic Bluetooth device filter for CDM pairing
+            BluetoothDeviceFilter deviceFilter = new BluetoothDeviceFilter.Builder()
+                // Optional: add device name pattern matching
+                // .setNamePattern(Pattern.compile(".*"))
+                .build();
+            
+            AssociationRequest pairingRequest = new AssociationRequest.Builder()
+                .addDeviceFilter(deviceFilter)
+                .setSingleDevice(false)  // Allow multiple device selection
+                .build();
+                
+            // Store the result to complete when pairing finishes
+            this.pendingPairingResult = result;
+            
+            companionDeviceManager.associate(pairingRequest,
+                new CompanionDeviceManager.Callback() {
+                    @Override
+                    public void onDeviceFound(IntentSender chooserLauncher) {
+                        try {
+                            activity.startIntentSenderForResult(chooserLauncher,
+                                REQUEST_CODE_CDM_PAIRING, null, 0, 0, 0);
+                        } catch (IntentSender.SendIntentException e) {
+                            Log.e(TAG, "Failed to start CDM chooser", e);
+                            if (pendingPairingResult != null) {
+                                pendingPairingResult.error("CHOOSER_FAILED", 
+                                    "Failed to start device chooser: " + e.getMessage(), null);
+                                pendingPairingResult = null;
+                            }
+                        }
+                    }
+                    
+                    @Override
+                    public void onFailure(CharSequence error) {
+                        Log.e(TAG, "CDM association failed: " + error);
+                        if (pendingPairingResult != null) {
+                            pendingPairingResult.error("CDM_PAIRING_FAILED", 
+                                "CDM pairing failed: " + error, null);
+                            pendingPairingResult = null;
+                        }
+                    }
+                }, null);
+                
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start CDM pairing", e);
+            result.error("CDM_ERROR", "Failed to start CDM pairing: " + e.getMessage(), null);
+        }
+    }
+    
+    /**
+     * Handle CDM pairing result from activity
+     */
+    public boolean handleCdmPairingResult(int requestCode, int resultCode, android.content.Intent data) {
+        if (requestCode != REQUEST_CODE_CDM_PAIRING) {
+            return false;
+        }
+        
+        if (pendingPairingResult == null) {
+            Log.w(TAG, "Received CDM pairing result but no pending result callback");
+            return true;
+        }
+        
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            try {
+                BluetoothDevice device = data.getParcelableExtra(CompanionDeviceManager.EXTRA_DEVICE);
+                if (device != null) {
+                    String deviceAddress = device.getAddress();
+                    
+                    // Add to CDM devices set for auto-bonding prevention
+                    cdmDevices.add(deviceAddress);
+                    
+                    Log.i(TAG, "CDM pairing successful for device: " + deviceAddress);
+                    pendingPairingResult.success(deviceAddress);
+                } else {
+                    pendingPairingResult.error("NO_DEVICE", "No device selected", null);
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Error processing CDM pairing result", e);
+                pendingPairingResult.error("RESULT_ERROR", 
+                    "Error processing pairing result: " + e.getMessage(), null);
+            }
+        } else {
+            Log.i(TAG, "CDM pairing cancelled by user");
+            pendingPairingResult.error("USER_CANCELLED", "User cancelled CDM pairing", null);
+        }
+        
+        pendingPairingResult = null;
+        return true;
+    }
+    
+    /**
+     * Remove CDM association for a device
+     */
+    public boolean removeAssociation(String deviceAddress) {
+        if (!isCdmSupported()) {
+            return false;
+        }
+        
+        try {
+            if (Build.VERSION.SDK_INT >= 33) { // Android 13+
+                // Use new disassociate method if available
+                companionDeviceManager.disassociate(deviceAddress);
+            } else {
+                // Fallback: CDM doesn't provide public disassociate before API 33
+                // The association will remain until the app is uninstalled
+                Log.w(TAG, "CDM disassociation not available before Android 13");
+                return false;
+            }
+            
+            // Remove from our tracking set
+            cdmDevices.remove(deviceAddress);
+            
+            Log.i(TAG, "Removed CDM association for device: " + deviceAddress);
+            return true;
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to remove CDM association: " + e.getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * Mark a device as CDM-associated for auto-bonding prevention
+     */
+    public void markAsCdmDevice(String deviceAddress) {
+        cdmDevices.add(deviceAddress);
+        Log.d(TAG, "Marked device as CDM: " + deviceAddress);
+    }
+    
+    /**
+     * Check if a device is tracked as CDM (either associated or manually marked)
+     */
+    public boolean isCdmDevice(String deviceAddress) {
+        return cdmDevices.contains(deviceAddress) || isDeviceAssociated(deviceAddress);
+    }
+    
+    /**
+     * Remove CDM tracking for a device
+     */
+    public void unmarkCdmDevice(String deviceAddress) {
+        cdmDevices.remove(deviceAddress);
+        Log.d(TAG, "Unmarked CDM device: " + deviceAddress);
+    }
+    
+    /**
+     * Get all currently tracked CDM devices (both associated and manually marked)
+     */
+    public Set<String> getTrackedCdmDevices() {
+        return java.util.Collections.unmodifiableSet(cdmDevices);
+    }
+    
+    /**
+     * Create a CDM-aware GATT callback that prevents auto-bonding
+     */
+    public BluetoothGattCallback createCdmGattCallback(String deviceAddress, 
+                                                      BluetoothGattCallback originalCallback) {
+        if (!isCdmDevice(deviceAddress)) {
+            return originalCallback;
+        }
+        
+        return new CdmGattCallback(deviceAddress, originalCallback);
+    }
+    
+    /**
+     * CDM-specific GATT callback that handles authentication differently
+     */
+    private class CdmGattCallback extends BluetoothGattCallback {
+        private final String deviceAddress;
+        private final BluetoothGattCallback originalCallback;
+        
+        public CdmGattCallback(String deviceAddress, BluetoothGattCallback originalCallback) {
+            this.deviceAddress = deviceAddress;
+            this.originalCallback = originalCallback;
+        }
+        
+        @Override
+        public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
+            Log.d(TAG, "CDM GATT connection state change: " + deviceAddress + 
+                  ", status: " + status + ", newState: " + newState);
+            originalCallback.onConnectionStateChange(gatt, status, newState);
+        }
+        
+        @Override
+        public void onServicesDiscovered(BluetoothGatt gatt, int status) {
+            Log.d(TAG, "CDM GATT services discovered: " + deviceAddress + ", status: " + status);
+            originalCallback.onServicesDiscovered(gatt, status);
+        }
+        
+        @Override
+        public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+            if (status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION) {
+                Log.w(TAG, "CDM device authentication required for read, but auto-bonding disabled: " + deviceAddress);
+                // Note: For CDM devices, this may be expected behavior
+                // The app should handle this or use alternative approaches
+            }
+            originalCallback.onCharacteristicRead(gatt, characteristic, status);
+        }
+        
+        @Override
+        public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+            if (status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION) {
+                Log.w(TAG, "CDM device authentication required for write, but auto-bonding disabled: " + deviceAddress);
+            }
+            originalCallback.onCharacteristicWrite(gatt, characteristic, status);
+        }
+        
+        @Override
+        public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
+            if (status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION) {
+                Log.w(TAG, "CDM device authentication required for descriptor write, but auto-bonding disabled: " + deviceAddress);
+                // This is the common case that causes problems with CDM devices
+                // They reject bonding when setNotifyValue tries to write CCCD
+            }
+            originalCallback.onDescriptorWrite(gatt, descriptor, status);
+        }
+        
+        @Override
+        public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
+            originalCallback.onCharacteristicChanged(gatt, characteristic);
+        }
+        
+        @Override
+        public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
+            originalCallback.onReadRemoteRssi(gatt, rssi, status);
+        }
+        
+        @Override
+        public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
+            originalCallback.onMtuChanged(gatt, mtu, status);
+        }
+    }
+}

--- a/packages/flutter_blue_plus_android/pubspec.yaml
+++ b/packages/flutter_blue_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus_android
 description: Android implementation of the flutter_blue_plus plugin.
-version: 4.0.5
+version: 4.1.0
 homepage: https://github.com/chipweinberger/flutter_blue_plus
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_blue_plus_platform_interface: ^4.0.2
+  flutter_blue_plus_platform_interface: ^4.1.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/packages/flutter_blue_plus_darwin/pubspec.yaml
+++ b/packages/flutter_blue_plus_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus_darwin
 description: iOS and macOS implementation of the flutter_blue_plus plugin.
-version: 4.0.1
+version: 4.1.0
 homepage: https://github.com/chipweinberger/flutter_blue_plus
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_blue_plus_platform_interface: ^4.0.0
+  flutter_blue_plus_platform_interface: ^4.1.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/packages/flutter_blue_plus_linux/pubspec.yaml
+++ b/packages/flutter_blue_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus_linux
 description: Linux implementation of the flutter_blue_plus plugin.
-version: 3.0.2
+version: 3.1.0
 homepage: https://github.com/chipweinberger/flutter_blue_plus
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   bluez: '>=0.7.8 <0.9.0'
   flutter:
     sdk: flutter
-  flutter_blue_plus_platform_interface: ^4.0.0
+  flutter_blue_plus_platform_interface: ^4.1.0
   rxdart: '>=0.27.0 <0.29.0'
 
 dev_dependencies:

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -215,16 +215,22 @@ class BmScanResponse {
 class BmConnectRequest {
   DeviceIdentifier remoteId;
   bool autoConnect;
+  bool allowAutoBonding;
+  bool isCdmDevice;
 
   BmConnectRequest({
     required this.remoteId,
     required this.autoConnect,
+    this.allowAutoBonding = true,
+    this.isCdmDevice = false,
   });
 
   Map<dynamic, dynamic> toMap() {
     final Map<dynamic, dynamic> data = {};
     data['remote_id'] = remoteId.str;
     data['auto_connect'] = autoConnect ? 1 : 0;
+    data['allow_auto_bonding'] = allowAutoBonding ? 1 : 0;
+    data['is_cdm_device'] = isCdmDevice ? 1 : 0;
     return data;
   }
 }

--- a/packages/flutter_blue_plus_platform_interface/pubspec.yaml
+++ b/packages/flutter_blue_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus_platform_interface
 description: A common platform interface for the flutter_blue_plus plugin.
-version: 4.0.2
+version: 4.1.0
 homepage: https://github.com/chipweinberger/flutter_blue_plus
 
 environment:

--- a/packages/flutter_blue_plus_web/pubspec.yaml
+++ b/packages/flutter_blue_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus_web
 description: Web implementation of the flutter_blue_plus plugin.
-version: 3.0.1
+version: 3.1.0
 homepage: https://github.com/chipweinberger/flutter_blue_plus
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_blue_plus_platform_interface: '>=3.0.0 <5.0.0'
+  flutter_blue_plus_platform_interface: ^4.1.0
   flutter_web_plugins:
     sdk: flutter
   web: '>=0.5.0 <2.0.0'


### PR DESCRIPTION
Platform Interface (flutter_blue_plus_platform_interface)

  - Added allowAutoBonding and isCdmDevice parameters to BmConnectRequest
  - Updated version 4.0.2 → 4.1.0

  Android Implementation (flutter_blue_plus_android)

  - Added CompanionDeviceManager import and initialization
  - Added CDM device tracking with mCdmDevices set
  - Modified connect method to read and store CDM flags
  - Added CDM authentication handling in onDescriptorWrite
  - Added native methods: isCdmDeviceAssociated and getCdmAssociatedDevices
  - Updated version 4.0.5 → 4.1.0

  Main Package (flutter_blue_plus)

  - Enhanced BluetoothDevice.connect() with allowAutoBonding and isCdmDevice parameters
  - Added BluetoothCdmHelper utility class with CDM detection and management methods
  - Added MethodChannel import for CDM native method calls
  - Updated version 1.35.5 → 1.36.0

  Example App

  - Added CDM device detection and badge display in scan results
  - Updated connection logic to use CDM-aware connection methods
  - Removed unused import

  Other Platform Packages

  - Updated flutter_blue_plus_darwin version 4.0.1 → 4.1.0
  - Updated flutter_blue_plus_linux version 3.0.2 → 3.1.0
  - Updated flutter_blue_plus_web version 3.0.1 → 3.1.0
  - All packages now reference flutter_blue_plus_platform_interface ^4.1.0

https://github.com/chipweinberger/flutter_blue_plus/issues/1248