### PR TITLE
Wipe known services on device disconnection

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -35,7 +35,8 @@ class BluetoothDevice {
 
   /// Get services
   ///  - returns empty if discoverServices() has not been called
-  ///    or if your device does not have any services (rare)
+  ///    after the most recent connection, or if your device
+  ///    does not have any services (rare)
   List<BluetoothService> get servicesList {
     BmDiscoverServicesResult? result = FlutterBluePlus._knownServices[remoteId];
     if (result == null) {
@@ -235,6 +236,9 @@ class BluetoothDevice {
             .fbpEnsureAdapterIsOn("disconnect")
             .fbpTimeout(timeout, "disconnect");
       }
+
+      // Wipe known services to avoid inconsistent state between Flutter and the platform
+      FlutterBluePlus._knownServices.remove(remoteId);
 
       if (!kIsWeb && Platform.isAndroid) {
         // Disconnected, remove connect timestamp


### PR DESCRIPTION
This bug has been observed on Android, but I think the fix applies to all platforms.

The following piece of code doesn't work:
```dart
BluetoothDevice btDevice = ...

// First connection
await btDevice.connect();
if (btDevice.servicesList.isEmpty) { // True
  await btDevice.discoverServices(); // Called, OK
}

print("${btDevice.servicesList}"); // Has services, OK

// Something happened, we need to disconnect
await btDevice.disconnect();

// After a while, reconnect to the device
await btDevice.connect();
if (btDevice.servicesList.isEmpty) { // False, still has services from before
  await btDevice.discoverServices(); // Not called 
}

final char = btDevice.servicesList.first.characteristics.first;
await char.read(); // Will throw "primary service not found"
```

The above happens because there's an inconsistency between the services cached in the Flutter side and those in the Android side. When `gatt.getServices()` is called in the Android code, no services are available because `gatt.discoverServices()` has not been called after the disconnection.

I think it's sane to wipe the known services once the device is disconnected as they become stale. I haven't investigated whether there is more stuff to wipe.


