### PR TITLE
[Fix] Linux: setNotifyValue: return false (no CCCD) to prevent hang

### DIFF
--- a/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
+++ b/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
@@ -794,7 +794,8 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
       await characteristic.stopNotify();
     }
 
-    return true;
+    // No CCCD write on Linux; no separate response event expected
+    return false;
   }
 
   @override
@@ -1130,4 +1131,3 @@ extension on BlueZClient {
     ).startWith(devices);
   }
 }
-


### PR DESCRIPTION
On Android, setNotifyValue works by calling writeDescriptor on the gatt object, and the platform independent code waits for that notification before returning. The same is not true on Linux, where setNotify does not involve a onDescriptorWritten notification, so all of the calls to setNotifyValue (including the one in connect to listen to service changes) are hanging.

This PR simply changes setNotifyValue on Linux to return false, but it could be reworked to push a notification to that channel instead.