### PR TITLE
[Fix] Linux: discoverServices: wait for servicesResolved to avoid partial results

### DIFF
--- a/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
+++ b/packages/flutter_blue_plus_linux/lib/flutter_blue_plus_linux.dart
@@ -352,6 +352,11 @@ final class FlutterBluePlusLinux extends FlutterBluePlusPlatform {
         },
       );
 
+      // Ensure BlueZ has completed service discovery before returning results
+      while (!device.servicesResolved) {
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+
       _onDiscoveredServicesController.add(
         BmDiscoverServicesResult(
           remoteId: device.remoteId,
@@ -1130,4 +1135,3 @@ extension on BlueZClient {
     ).startWith(devices);
   }
 }
-


### PR DESCRIPTION
On Linux, we need to wait for BlueZ to indicate that services are ready before returning them, otherwise a partial list is usually returned.
