### PR TITLE
[iOS] Initialise showPowerAlert to false

### DIFF
--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     instance.writeDescs = [NSMutableDictionary new];
     instance.scanCounts = [NSMutableDictionary new];
     instance.logLevel = LDEBUG;
-    instance.showPowerAlert = @(YES);
+    instance.showPowerAlert = @(NO);
     instance.restoreState = @(NO);
 
     [registrar addMethodCallDelegate:instance channel:methodChannel];


### PR DESCRIPTION
See https://github.com/chipweinberger/flutter_blue_plus/issues/1098, I found this issue late while investigating but it describes exactly the problem I was also having.

I tried to avoid introducing a breaking change, but I'm out of ideas.

# Description
`showPowerAlert`'s default value becomes `@(NO)`.

When a flutter application with FBP starts, `handleMethodCall` gets called with argument `flutterRestart` before anything in the `main` method can execute, including the call to FBP's `setOptions`.

This results in the CBCentralManager always initialising with the default values, implying that `CBCentralManagerOptionShowPowerAlertKey` starts at true. 

However, calling `setOptions` with `showPowerAlert = false` after the CBCentralManger was initialised does not apply the change, firstly because the previous implementation made it return immediately, so if it was already initialised changing the options did nothing. Then after testing, even if the CBCentralManager is reinitialised completely, the behaviour remains as if `showPowerAlert = true`.

Simply changing the default fixes the issue, but breaks functionality when `setOptions` is called with `showPowerAlert = true`. It behaves correctly again after reinitialising the CBCentralManager any time `setOptions` is called with different settings than what were previously used.

Strangely, I did another test that included the `CBCentralManagerOptionShowPowerAlertKey` key only if `showPowerAlert` was false, going by the [documented logic](https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionshowpoweralertkey) that if the key wasn't included it defaulted to true anyway, yet the alert never shows up in that case in the first place.

## Testing done
Scenario 1:
Not calling `setOptions`: new default is false, therefore the power alert no longer shows. This is the breaking change.

Scenario 2:
Calling `setOptions` with `showPowerAlert = false`: the power alert does not show, as intended. Fixed by this PR.

Scenario 3:
Calling `setOptions` with `showPowerAlert = true`: the power alert shows up as intended. No changes here.
