### PR TITLE
android: don't crash reading a device name without BLUETOOTH_CONNECT

### DIFF
--- a/packages/flutter_blue_plus_android/android/src/main/java/com/jmx/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/jmx/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -394,6 +394,15 @@ public class FlutterBluePlusPlugin implements
 
                     ensurePermissions(permissions, (granted, perm) -> {
 
+                        // BluetoothAdapter.getName() requires BLUETOOTH_CONNECT on Android 12+, so a
+                        // refusal has to be honoured: calling it anyway throws SecurityException, which
+                        // crashes the app. Empty string matches what a null adapter name already returns.
+                        if (!granted) {
+                            Log.w(TAG, "Cannot read the adapter name without " + perm + ".");
+                            result.success("");
+                            return;
+                        }
+
                         String adapterName = mBluetoothAdapter != null ? mBluetoothAdapter.getName() : "N/A";
                         result.success(adapterName != null ? adapterName : "");
 
@@ -514,8 +523,11 @@ public class FlutterBluePlusPlugin implements
                         if (androidUsesFineLocation) {
                             permissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
                         }
-                        // it is unclear why this is needed, but some phones throw a
-                        // SecurityException AdapterService getRemoteName, without it
+                        // Scan results are turned into advertisements via BluetoothDevice.getName(),
+                        // which reaches AdapterService.getRemoteName() and requires BLUETOOTH_CONNECT --
+                        // hence the SecurityException some phones throw without it. Requesting it up
+                        // front covers the normal case; safeDeviceName() covers the one it cannot, where
+                        // the permission is revoked while a scan or connection is already live.
                         permissions.add(Manifest.permission.BLUETOOTH_CONNECT);
                     }
 
@@ -2722,8 +2734,9 @@ public class FlutterBluePlusPlugin implements
         // See: BmScanAdvertisement
         // perf: only add keys if they exists
         HashMap<String, Object> map = new HashMap<>();
+        String deviceName = safeDeviceName(device);
         if (device.getAddress() != null) {map.put("remote_id", device.getAddress());};
-        if (device.getName() != null)    {map.put("platform_name", device.getName());}
+        if (deviceName != null)          {map.put("platform_name", deviceName);}
         if (connectable)                 {map.put("connectable", 1);}
         if (advName != null)             {map.put("adv_name", advName);}
         if (txPower != min)              {map.put("tx_power_level", txPower);}
@@ -2735,11 +2748,27 @@ public class FlutterBluePlusPlugin implements
         return map;
     }
 
+    /**
+     * BLUETOOTH_CONNECT can be revoked while a scan or connection is live. getName() then throws
+     * SecurityException -- often from inside one of the stack's own callbacks, on a binder thread --
+     * which brings the app down before Android gets round to killing the process for the revocation
+     * itself. The name is optional metadata (platform_name is nullable on the Dart side), so report it
+     * as unknown instead of crashing.
+     */
+    private String safeDeviceName(BluetoothDevice device) {
+        try {
+            return device.getName();
+        } catch (SecurityException e) {
+            Log.w(TAG, "No permission to read the remote device name.", e);
+            return null;
+        }
+    }
+
     // See: BmBluetoothDevice
     HashMap<String, Object> bmBluetoothDevice(BluetoothDevice device) {
         HashMap<String, Object> map = new HashMap<>();
         map.put("remote_id", device.getAddress());
-        map.put("platform_name", device.getName());
+        map.put("platform_name", safeDeviceName(device));
         return map;
     }
 


### PR DESCRIPTION
### The crash

`BluetoothDevice.getName()` reaches `AdapterService.getRemoteName()`, which requires `BLUETOOTH_CONNECT` on Android 12+. If the user revokes *Nearby devices* while a scan or connection is live, the stack raises `SecurityException` **from inside its own callbacks, on a binder thread**, and the app dies:

```
java.lang.SecurityException: Need android.permission.BLUETOOTH_CONNECT permission for
android.content.AttributionSource@1d6babb5: AdapterService getRemoteName
    at com.android.bluetooth.Utils.checkPermissionForDataDelivery(Utils.java:509)
    at com.android.bluetooth.btservice.AdapterService$AdapterServiceBinder.getRemoteName(AdapterService.java:3197)
    at android.os.Binder.execTransactInternal(Binder.java:1359)
```

Requesting the permission up front — which `startScan` already does — cannot prevent it, because the permission disappears *after* the grant. Nothing can be asked for from inside a stack callback either.

### The fix

- `bmScanAdvertisement` and `bmBluetoothDevice` read the name through a small `safeDeviceName()` helper that returns `null` on `SecurityException`. `platform_name` is already `String?` on the Dart side, so a missing name degrades cleanly instead of killing the process.
- `getAdapterName` is a different case: it *does* ask, through `ensurePermissions`, but ignored the result and called `getName()` regardless, so a refusal crashed rather than returning. It now honours `granted` and returns `""` — the same thing a null adapter name already produces.
- The `// it is unclear why this is needed` comment above the `BLUETOOTH_CONNECT` request in `startScan` is replaced with the actual mechanism, since it is the same one: scan results are converted with `getName()`, which is why those phones threw `SecurityException` from `getRemoteName` without it.

### Testing

Found while chasing an app that crash-looped whenever a user revoked Nearby devices. Reproduced and verified on a **Pixel 7 (Android 16)** and a **moto g 5G (Android 14)**: revoking the permission during an active connection produced a fatal `SecurityException` on every run before this change, and leaves an empty crash buffer after it. Normal scan/connect behaviour is unchanged — the name is only ever null in the state that used to crash.

No public API change.