### PR TITLE
feat(android): expose ACL link state as onAclStateChanged

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_events.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_events.dart
@@ -44,6 +44,10 @@ class BluetoothEvents {
   Stream<OnBondStateChangedEvent> get onBondStateChanged {
     return FlutterBluePlusPlatform.instance.onBondStateChanged.map((p) => OnBondStateChangedEvent(p));
   }
+
+  Stream<OnAclStateChangedEvent> get onAclStateChanged {
+    return FlutterBluePlusPlatform.instance.onAclStateChanged.map((p) => OnAclStateChangedEvent(p));
+  }
 }
 
 class FbpError {
@@ -240,6 +244,18 @@ class OnNameChangedEvent {
 }
 
 // On Bond State Changed
+class OnAclStateChangedEvent {
+  final BmAclStateResponse _response;
+
+  OnAclStateChangedEvent(this._response);
+
+  /// the relevant device
+  BluetoothDevice get device => BluetoothDevice(remoteId: _response.remoteId);
+
+  /// whether an ACL link to the device is up
+  bool get connected => _response.connected;
+}
+
 class OnBondStateChangedEvent {
   final BmBondStateResponse _response;
 

--- a/packages/flutter_blue_plus_android/android/src/main/java/com/jmx/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/jmx/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -209,6 +209,11 @@ public class FlutterBluePlusPlugin implements
 
         IntentFilter filterBond = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
         this.context.registerReceiver(mBluetoothBondStateReceiver, filterBond);
+
+        IntentFilter filterAcl = new IntentFilter();
+        filterAcl.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+        filterAcl.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+        this.context.registerReceiver(mBluetoothAclReceiver, filterAcl);
     }
 
     @Override
@@ -232,6 +237,7 @@ public class FlutterBluePlusPlugin implements
 
         disconnectAllDevices("onDetachedFromEngine");
 
+        context.unregisterReceiver(mBluetoothAclReceiver);
         context.unregisterReceiver(mBluetoothBondStateReceiver);
         context.unregisterReceiver(mBluetoothPairRequestReceiver);
         context.unregisterReceiver(mBluetoothAdapterStateReceiver);
@@ -2113,6 +2119,48 @@ public class FlutterBluePlusPlugin implements
             map.put("prev_state", bmBondStateEnum(prev));
 
             invokeMethodUIThread("OnBondStateChanged", map);
+        }
+    };
+
+    /// ACL link came up or went down.
+    ///
+    /// ATT MTU is negotiated once per ACL connection and shared by every GATT client on it, so the
+    /// GATT connection state cannot tell you whether a new MTU exchange is possible. This can.
+    private final BroadcastReceiver mBluetoothAclReceiver = new BroadcastReceiver()
+    {
+        @Override
+        @SuppressWarnings("deprecation") // need for compatability
+        public void onReceive(Context context, Intent intent)
+        {
+            final String action = intent.getAction();
+
+            boolean connected;
+            if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
+                connected = true;
+            } else if (BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)) {
+                connected = false;
+            } else {
+                return;
+            }
+
+            final BluetoothDevice device;
+            if (Build.VERSION.SDK_INT >= 33) { // Android 13 (August 2022)
+                device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice.class);
+            } else {
+                device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+            }
+            if (device == null) {
+                return;
+            }
+
+            log(LogLevel.DEBUG, "OnAclStateChanged: " + (connected ? "connected" : "disconnected"));
+
+            // see: BmAclStateResponse
+            HashMap<String, Object> map = new HashMap<>();
+            map.put("remote_id", device.getAddress());
+            map.put("connected", connected);
+
+            invokeMethodUIThread("OnAclStateChanged", map);
         }
     };
 

--- a/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart
+++ b/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart
@@ -14,6 +14,7 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
   var _logColor = true;
 
   final _onAdapterStateChangedController = StreamController<BmBluetoothAdapterState>.broadcast();
+  final _onAclStateChangedController = StreamController<BmAclStateResponse>.broadcast();
   final _onBondStateChangedController = StreamController<BmBondStateResponse>.broadcast();
   final _onCharacteristicReceivedController = StreamController<BmCharacteristicData>.broadcast();
   final _onCharacteristicWrittenController = StreamController<BmCharacteristicData>.broadcast();
@@ -37,6 +38,11 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
   @override
   Stream<BmBondStateResponse> get onBondStateChanged {
     return _onBondStateChangedController.stream;
+  }
+
+  @override
+  Stream<BmAclStateResponse> get onAclStateChanged {
+    return _onAclStateChangedController.stream;
   }
 
   @override
@@ -483,6 +489,12 @@ final class FlutterBluePlusAndroid extends FlutterBluePlusPlatform {
       case 'OnAdapterStateChanged':
         return _onAdapterStateChangedController.add(
           BmBluetoothAdapterState.fromMap(
+            call.arguments,
+          ),
+        );
+      case 'OnAclStateChanged':
+        return _onAclStateChangedController.add(
+          BmAclStateResponse.fromMap(
             call.arguments,
           ),
         );

--- a/packages/flutter_blue_plus_platform_interface/lib/flutter_blue_plus_platform_interface.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/flutter_blue_plus_platform_interface.dart
@@ -31,6 +31,10 @@ abstract base class FlutterBluePlusPlatform {
     _instance = instance;
   }
 
+  Stream<BmAclStateResponse> get onAclStateChanged {
+    return Stream.empty();
+  }
+
   Stream<BmBluetoothAdapterState> get onAdapterStateChanged {
     return Stream.empty();
   }

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -902,6 +902,27 @@ class BmBondStateResponse {
   }
 }
 
+/// An ACL link came up or went down.
+///
+/// ACL state is a property of the link, shared by every GATT client on it, so this is not scoped to
+/// the calling app.
+class BmAclStateResponse {
+  final DeviceIdentifier remoteId;
+  final bool connected;
+
+  BmAclStateResponse({
+    required this.remoteId,
+    required this.connected,
+  });
+
+  factory BmAclStateResponse.fromMap(Map<dynamic, dynamic> json) {
+    return BmAclStateResponse(
+      remoteId: DeviceIdentifier(json['remote_id']),
+      connected: json['connected'] as bool,
+    );
+  }
+}
+
 class BmCreateBondRequest {
   DeviceIdentifier remoteId;
   Uint8List? pin;


### PR DESCRIPTION
## Problem

On Android, `disconnect()` can return while the ACL link is still up. FBP then reports the device as
disconnected — `isConnected` is false, `connectionState` has emitted `disconnected` — but the radio
link is still there. A following `connect()` then "succeeds" almost instantly by attaching to that
surviving link.

That silent reuse breaks anything the caller expected a new connection to reset. The clearest case is
the ATT MTU, which is negotiated **once per ACL connection** and shared by every GATT client on it:

- `requestMtu()` returns the previous value and `onMtuChanged` fires, so it looks like it worked
- but nothing goes out on the wire — no `ATT Exchange MTU Request` at all
- so a caller that connected with a bad MTU can never recover, no matter how many times it retries

We measured this with an HCI capture on a Pixel: **120 retry attempts produced 1 real
`LE Connection Complete` and 1 real MTU exchange.** The app was told all 120 succeeded.

There is currently no way to detect this from the plugin's API. `isConnected` and `connectionState`
both read FBP's own cache, so neither can see a link the plugin has lost track of.
`getSystemDevices` (`BluetoothManager.getConnectedDevices(GATT)`) does ask the OS, but it can only be
polled against a timeout, and it reports links held by *any* app so it can't be attributed.

## Likely the same race as `androidDelay`

We think this is the other half of the problem `disconnect(androidDelay:)` already documents:

> `[androidDelay]` Android only. Minimum gap in milliseconds between connect and disconnect to
> workaround a race condition that leaves connection stranded. A stranded connection in this case
> refers to a connection that FBP and Android Bluetooth stack are not aware of and thus cannot be
> disconnected because there is no gatt handle.
> https://issuetracker.google.com/issues/37121040
> From testing, 2 second delay appears to be enough.

`androidDelay` guards connect → disconnect, and prevents the strand by not issuing a disconnect during
establishment. What we hit is the same class of desync in the other direction — disconnect → connect —
where FBP's view and the radio's view disagree. A fixed delay can't help there, because there is
nothing to wait *for*: you need a signal.

## What this adds

`ACTION_ACL_CONNECTED` / `ACTION_ACL_DISCONNECTED`, surfaced as
`FlutterBluePlus.events.onAclStateChanged` (`BmAclStateResponse` on the platform interface). ACL state
is a property of the link, which is exactly the scope that matters for per-connection state like the
MTU. Other platforms inherit the default empty stream, so nothing changes for them.

Waiting for `ACL_DISCONNECTED` before reconnecting is what fixed it for us.

## Verification

Measured against an HCI capture (`dumpcap -i bluetooth-monitor`, decoded independently):

| | result |
|---|---|
| `ACL_DISCONNECTED` vs wire `Disconnect Complete` | 21/21, +21 to +47 ms, no outliers |
| `ACL_CONNECTED` vs wire `LE Connection Complete` | 21/21, +46 to +82 ms, no outliers |
| reconnect after awaiting the event | 20/20 fresh links, 20/20 real MTU exchanges |
| reconnect immediately (control) | 0/20 — no wire connections, no exchanges, link reused |
| soak, 2 peers | 285 connect/disconnect cycles, every MTU exchange real |

For reference, the ACL takes 4080–4149 ms to actually drop after `disconnect()` on this hardware
(n=15), which is why a short fixed delay isn't enough and the event matters.

## Caveat on testing

Our app runs a fork based on `flutter_blue_plus` 1.36.8, and all the device measurements above come
from there. This branch is the same change ported onto current `master` (2.3.12 / android 9.0.3): the
anchors and helpers are unchanged, and all three touched packages pass `dart analyze`, but I have
**not** re-run the on-device tests against 2.x. Happy to adjust naming or placement to taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
