### PR TITLE
perf: platform-appropriate operation queue defaults (iOS unqueued, Android per-device)

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart
@@ -128,7 +128,7 @@ class BluetoothCharacteristic {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     // return value
@@ -200,7 +200,7 @@ class BluetoothCharacteristic {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     try {
@@ -266,7 +266,7 @@ class BluetoothCharacteristic {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     try {

--- a/packages/flutter_blue_plus/lib/src/bluetooth_descriptor.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_descriptor.dart
@@ -101,7 +101,7 @@ class BluetoothDescriptor {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     // return value
@@ -159,7 +159,7 @@ class BluetoothDescriptor {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     try {

--- a/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_device.dart
@@ -118,7 +118,7 @@ class BluetoothDevice {
     bool dtook = await dmtx.take();
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     try {
@@ -214,7 +214,7 @@ class BluetoothDevice {
     await dtx.take();
 
     // Queue behind other operations for this device only.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     if (queue) {
       await mtx.take();
     }
@@ -267,7 +267,7 @@ class BluetoothDevice {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     List<BluetoothService> result = [];
@@ -375,7 +375,7 @@ class BluetoothDevice {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     int rssi = 0;
@@ -424,7 +424,7 @@ class BluetoothDevice {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     // predelay
@@ -548,7 +548,7 @@ class BluetoothDevice {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     try {
@@ -589,7 +589,7 @@ class BluetoothDevice {
     }
 
     // Only allow a single BLE operation to be underway per device.
-    _Mutex mtx = _MutexFactory.getMutexForKey(FlutterBluePlus._bleOperationMutexKey(remoteId));
+    _Mutex mtx = FlutterBluePlus._bleOperationMutex(remoteId);
     await mtx.take();
 
     try {

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -46,7 +46,13 @@ class FlutterBluePlus {
 
   /// FlutterBluePlus log level
   static LogLevel _logLevel = LogLevel.debug;
-  static OperationQueueMode _operationQueueMode = _defaultOperationQueueMode;
+  static OperationQueueMode? _operationQueueModeOverride;
+
+  /// Resolved at call time, not cached, so the platform default cannot be
+  /// captured before a test overrides the target platform.
+  static OperationQueueMode get _operationQueueMode {
+    return _operationQueueModeOverride ?? _defaultOperationQueueMode;
+  }
 
   /// Per-platform defaults, chosen to match what each platform actually constrains:
   ///  - iOS: [OperationQueueMode.unqueued]. CoreBluetooth manages its own requests.
@@ -57,13 +63,14 @@ class FlutterBluePlus {
     if (kIsWeb) {
       return OperationQueueMode.global;
     }
-    if (Platform.isIOS) {
-      return OperationQueueMode.unqueued;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        return OperationQueueMode.unqueued;
+      case TargetPlatform.android:
+        return OperationQueueMode.perDevice;
+      default:
+        return OperationQueueMode.global;
     }
-    if (Platform.isAndroid) {
-      return OperationQueueMode.perDevice;
-    }
-    return OperationQueueMode.global;
   }
 
   ////////////////////
@@ -152,7 +159,13 @@ class FlutterBluePlus {
       throw StateError("setOperationQueueMode must be called before starting any BLE work");
     }
 
-    _operationQueueMode = mode;
+    _operationQueueModeOverride = mode;
+  }
+
+  /// Drop any explicit mode and go back to the platform default. Test-only.
+  @visibleForTesting
+  static void resetOperationQueueMode() {
+    _operationQueueModeOverride = null;
   }
 
   /// Set configurable options

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -48,10 +48,22 @@ class FlutterBluePlus {
   static LogLevel _logLevel = LogLevel.debug;
   static OperationQueueMode _operationQueueMode = _defaultOperationQueueMode;
 
-  /// iOS defaults to [OperationQueueMode.unqueued]; every other platform keeps
-  /// [OperationQueueMode.global] for backward compatibility.
+  /// Per-platform defaults, chosen to match what each platform actually constrains:
+  ///  - iOS: [OperationQueueMode.unqueued]. CoreBluetooth manages its own requests.
+  ///  - Android: [OperationQueueMode.perDevice]. `mDeviceBusy` is per `BluetoothGatt`, so the
+  ///    constraint is per connection and a global queue blocks unrelated devices.
+  ///  - everything else: [OperationQueueMode.global], unchanged.
   static OperationQueueMode get _defaultOperationQueueMode {
-    return (!kIsWeb && Platform.isIOS) ? OperationQueueMode.unqueued : OperationQueueMode.global;
+    if (kIsWeb) {
+      return OperationQueueMode.global;
+    }
+    if (Platform.isIOS) {
+      return OperationQueueMode.unqueued;
+    }
+    if (Platform.isAndroid) {
+      return OperationQueueMode.perDevice;
+    }
+    return OperationQueueMode.global;
   }
 
   ////////////////////
@@ -121,9 +133,10 @@ class FlutterBluePlus {
   ///   is the default on iOS, where CoreBluetooth already manages its own
   ///   requests. The disconnect mutex still applies.
   ///
-  /// We recommend [OperationQueueMode.perDevice] for new apps.
-  /// [OperationQueueMode.global] remains the default for backward
-  /// compatibility.
+  /// Defaults are per-platform: [OperationQueueMode.unqueued] on iOS,
+  /// [OperationQueueMode.perDevice] on Android, and
+  /// [OperationQueueMode.global] elsewhere. Pass [OperationQueueMode.global]
+  /// explicitly to restore the historical behavior on any platform.
   ///
   /// This is useful if your app talks to multiple devices at the same time
   /// as it allows simultaneous device writing, discovery, and reads.

--- a/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
+++ b/packages/flutter_blue_plus/lib/src/flutter_blue_plus.dart
@@ -46,7 +46,13 @@ class FlutterBluePlus {
 
   /// FlutterBluePlus log level
   static LogLevel _logLevel = LogLevel.debug;
-  static OperationQueueMode _operationQueueMode = OperationQueueMode.global;
+  static OperationQueueMode _operationQueueMode = _defaultOperationQueueMode;
+
+  /// iOS defaults to [OperationQueueMode.unqueued]; every other platform keeps
+  /// [OperationQueueMode.global] for backward compatibility.
+  static OperationQueueMode get _defaultOperationQueueMode {
+    return (!kIsWeb && Platform.isIOS) ? OperationQueueMode.unqueued : OperationQueueMode.global;
+  }
 
   ////////////////////
   //  Public
@@ -111,6 +117,9 @@ class FlutterBluePlus {
   ///   only one BLE operation at a time across the whole app.
   /// - [OperationQueueMode.perDevice] allows operations for different devices
   ///   to proceed concurrently, while still serializing operations per device.
+  /// - [OperationQueueMode.unqueued] does not serialize operations at all. This
+  ///   is the default on iOS, where CoreBluetooth already manages its own
+  ///   requests. The disconnect mutex still applies.
   ///
   /// We recommend [OperationQueueMode.perDevice] for new apps.
   /// [OperationQueueMode.global] remains the default for backward
@@ -151,11 +160,20 @@ class FlutterBluePlus {
   }
 
   static String _bleOperationMutexKey(DeviceIdentifier remoteId) {
-    return _operationQueueMode == OperationQueueMode.perDevice ? "device:$remoteId" : "global";
+    return _operationQueueMode == OperationQueueMode.global ? "global" : "device:$remoteId";
   }
 
   static String _disconnectMutexKey(DeviceIdentifier remoteId) {
-    return _operationQueueMode == OperationQueueMode.perDevice ? "disconnect:$remoteId" : "disconnect";
+    return _operationQueueMode == OperationQueueMode.global ? "disconnect" : "disconnect:$remoteId";
+  }
+
+  /// The mutex that serialises BLE operations. Bypassed entirely under
+  /// [OperationQueueMode.unqueued]; the disconnect mutex is never bypassed.
+  static _Mutex _bleOperationMutex(DeviceIdentifier remoteId) {
+    return _MutexFactory.getMutexForKey(
+      _bleOperationMutexKey(remoteId),
+      bypass: _operationQueueMode == OperationQueueMode.unqueued,
+    );
   }
 
   static bool _hasOperationMutexesForMode(OperationQueueMode mode) {
@@ -675,6 +693,14 @@ enum OperationQueueMode {
   /// This allows operations on different devices to run concurrently while
   /// still preserving ordering for each individual device.
   perDevice,
+
+  /// Do not queue BLE operations at all.
+  ///
+  /// This is the default on iOS. CoreBluetooth completes acknowledged requests
+  /// via its delegate callbacks and exposes explicit flow control only for
+  /// writes without response, so serializing in Dart adds latency without
+  /// preventing anything.
+  unqueued,
 }
 
 class AndroidScanMode {

--- a/packages/flutter_blue_plus/lib/src/mutex_factory.dart
+++ b/packages/flutter_blue_plus/lib/src/mutex_factory.dart
@@ -3,11 +3,19 @@ part of '../flutter_blue_plus.dart';
 // dart is single threaded, but still has task switching.
 // this mutex lets a single task through at a time.
 class _Mutex {
+  _Mutex({this.bypass = false});
+
+  /// When true, take/give do nothing. Used by [OperationQueueMode.unqueued].
+  final bool bypass;
+
   final StreamController _controller = StreamController.broadcast();
   int execute = 0;
   int issued = 0;
 
   Future<bool> take() async {
+    if (bypass) {
+      return true;
+    }
     int mine = issued;
     issued++;
     // tasks are executed in the same order they call take()
@@ -18,6 +26,9 @@ class _Mutex {
   }
 
   bool give() {
+    if (bypass) {
+      return false;
+    }
     execute++;
     _controller.add(null); // release waiting tasks
     return false;
@@ -28,8 +39,8 @@ class _Mutex {
 class _MutexFactory {
   static final Map<String, _Mutex> _all = {};
 
-  static _Mutex getMutexForKey(String key) {
-    _all[key] ??= _Mutex();
+  static _Mutex getMutexForKey(String key, {bool bypass = false}) {
+    _all[key] ??= _Mutex(bypass: bypass);
     return _all[key]!;
   }
 


### PR DESCRIPTION
## What

Adds `OperationQueueMode.unqueued` and sets defaults per platform, matching what each platform actually
constrains:

| platform | default | rationale |
|---|---|---|
| Android | `perDevice` | the busy flag is per connection, not global |
| iOS | `unqueued` | CoreBluetooth manages its own requests |
| web / linux / macOS / windows | `global` | unchanged |

`setOperationQueueMode(OperationQueueMode.global)` restores the old behaviour on any platform.

**The disconnect mutex is never bypassed** — `_disconnectMutexKey` still gets a real mutex, so
Dart-side `connect`/`disconnect` ordering is preserved everywhere. Only the operation mutex is affected.

## Android: the constraint is per-connection, so a global queue is too coarse

The thing a queue protects against on Android is `mDeviceBusy` in
[AOSP's `BluetoothGatt`](https://android.googlesource.com/platform/packages/modules/Bluetooth/+/refs/heads/main/framework/java/android/bluetooth/BluetoothGatt.java).
It is **per instance, not static**:

```java
private Boolean mDeviceBusy = false;
```

and it gates operations:

```java
// readCharacteristic
synchronized (mDeviceBusyLock) {
    if (mDeviceBusy) return false;
    mDeviceBusy = true;
}

// writeCharacteristic
synchronized (mDeviceBusyLock) {
    if (mDeviceBusy) {
        return BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY;
    }
    mDeviceBusy = true;
}
```

A `BluetoothGatt` is obtained per device from `connectGatt`, so this is a **per-connection** limit — the
public error constant is even named
[`ERROR_GATT_WRITE_REQUEST_BUSY`](https://developer.android.com/reference/android/bluetooth/BluetoothStatusCodes#ERROR_GATT_WRITE_REQUEST_BUSY).
A global Dart queue therefore blocks operations on device B to satisfy a limit that only exists on
device A. `perDevice` maps exactly onto the constraint: still serialised where the platform requires it,
concurrent where it doesn't.

This is also why the documented booleans report *initiation*, not success —
[`requestMtu(int)`](https://developer.android.com/reference/android/bluetooth/BluetoothGatt#requestMtu(int))
returns "true, if the new MTU value has been requested successfully".

## iOS: no equivalent constraint

CoreBluetooth exposes explicit flow control for exactly one thing — writes *without* response:

- [`CBPeripheral.canSendWriteWithoutResponse`](https://developer.apple.com/documentation/corebluetooth/cbperipheral/cansendwritewithoutresponse)
  — "A Boolean value that indicates whether the remote device can send a write without a response."
- [`peripheralIsReady(toSendWriteWithoutResponse:)`](https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/peripheralisready(tosendwritewithoutresponse:))
  — "Tells the delegate that a peripheral is again ready to send characteristic updates."
- [WWDC17 session 712](https://developer.apple.com/videos/play/wwdc2017/712/) — introduced because
  unacknowledged writes could otherwise be dropped in software with no notification.

There is no readiness signal for acknowledged operations, because those complete via delegate callbacks
on the single queue passed to
[`init(delegate:queue:)`](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/init(delegate:queue:)).
FBP doesn't use the mutex to pace write-without-response — the one case Apple says needs pacing.

**Straight about the evidence:** Apple doesn't publish a statement that CoreBluetooth serialises
concurrent requests per peripheral, and I'm not claiming it does. The iOS case rests on the documented
asymmetry above plus field data. The Android case rests on AOSP source, which is unambiguous.

## Field evidence

Allthenticate runs both defaults in production — thousands of devices, continuous BLE traffic (connect,
service discovery, characteristic reads/writes, notifications) against door readers and desktops, over
a wide spread of OS versions and hardware. The app talks to several resources concurrently, which is
precisely the case a global queue penalises.

- **per-device on Android since 2025-11-25**
- **unqueued on iOS since 2025-12-18**

No dropped, reordered or lost operations attributable to either change. We shipped something *more*
aggressive than this PR — our build also bypassed the disconnect mutex — so this patch is strictly more
conservative than what the field data covers.

## Risk, and a smaller version if you'd prefer

Changing defaults changes behaviour for existing apps, which is why you kept `global`. If that's too
much at once, the useful decomposition is: land `unqueued` and the Android `perDevice` default
separately, or land the new mode with **no** default changes and just document the recommendation.
Happy to cut it either way.

One genuine risk: `_Mutex` also orders FBP's own Dart-side work, not only the radio. Retaining the
disconnect mutex covers the case we thought most likely to matter, but an internal sequence relying on
operation-level serialisation would be exposed by this.

macOS uses the same CoreBluetooth APIs and arguably wants `unqueued` too — I left it on `global`
because our field data is iOS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
